### PR TITLE
feat: transcript-based session audit with strict extraction rules

### DIFF
--- a/src/agents/memory-extractor.ts
+++ b/src/agents/memory-extractor.ts
@@ -63,17 +63,14 @@ export async function runMemoryExtraction(opts: {
   sessionEvents: string;
   projectPath: string;
   model?: string;
-  budgetUsd?: number;
 }): Promise<MemoryExtractionResult> {
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   const startTime = Date.now();
   const model = opts.model ?? "claude-haiku-4-5";
-  const budgetUsd = opts.budgetUsd ?? 0.5;
 
   const queryOpts = {
     cwd: opts.projectPath,
     model,
-    maxBudgetUsd: budgetUsd,
     permissionMode: "bypassPermissions" as const,
     allowDangerouslySkipPermissions: true,
     allowedTools: [] as string[],

--- a/src/agents/scanners/decision.ts
+++ b/src/agents/scanners/decision.ts
@@ -96,15 +96,13 @@ Do NOT include:
 export async function runDecisionScan(opts: {
   projectPath: string;
   model?: string;
-  budgetUsd?: number;
 }): Promise<DecisionScanResult> {
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   const startTime = Date.now();
   const model = opts.model ?? "claude-sonnet-4-6";
-  const budgetUsd = opts.budgetUsd ?? 1;
 
   const queryOpts = buildAgentQueryOptions(
-    { cwd: opts.projectPath, model, budgetUsd },
+    { cwd: opts.projectPath, model },
     "scanner",
   );
 

--- a/src/agents/scanners/deploy.ts
+++ b/src/agents/scanners/deploy.ts
@@ -85,15 +85,13 @@ Rules:
 export async function runDeployScan(opts: {
   projectPath: string;
   model?: string;
-  budgetUsd?: number;
 }): Promise<DeployScanResult> {
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   const startTime = Date.now();
   const model = opts.model ?? "claude-haiku-4-5";
-  const budgetUsd = opts.budgetUsd ?? 0.5;
 
   const queryOpts = buildAgentQueryOptions(
-    { cwd: opts.projectPath, model, budgetUsd },
+    { cwd: opts.projectPath, model },
     "scanner",
   );
 

--- a/src/agents/scanners/oracle.ts
+++ b/src/agents/scanners/oracle.ts
@@ -117,17 +117,15 @@ Write in markdown as a definition list. Include terms from README, source code, 
 export async function runOracleScan(opts: {
   projectPath: string;
   model?: string;
-  budgetUsd?: number;
   workspaceMode?: boolean;
   customPaths?: string[];
 }): Promise<OracleScanResult> {
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   const startTime = Date.now();
   const model = opts.model ?? "claude-sonnet-4-6";
-  const budgetUsd = opts.budgetUsd ?? 1;
 
   const queryOpts = buildAgentQueryOptions(
-    { cwd: opts.projectPath, model, budgetUsd },
+    { cwd: opts.projectPath, model },
     "scanner",
   );
 

--- a/src/agents/scanners/safety.ts
+++ b/src/agents/scanners/safety.ts
@@ -93,15 +93,13 @@ protectedBranches: [list of branches, e.g., main, develop]
 export async function runSafetyScan(opts: {
   projectPath: string;
   model?: string;
-  budgetUsd?: number;
 }): Promise<SafetyScanResult> {
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   const startTime = Date.now();
   const model = opts.model ?? "claude-haiku-4-5";
-  const budgetUsd = opts.budgetUsd ?? 0.5;
 
   const queryOpts = buildAgentQueryOptions(
-    { cwd: opts.projectPath, model, budgetUsd },
+    { cwd: opts.projectPath, model },
     "scanner",
   );
 

--- a/src/agents/session-auditor.ts
+++ b/src/agents/session-auditor.ts
@@ -1,20 +1,27 @@
 /**
  * Session Auditor Agent - post-session LLM analysis.
  *
- * Extracts ALL storage module updates from a session:
- * - Memories (feedback + patterns)
- * - Decisions (new architectural decisions)
- * - Safety rules (new constraints)
- * - Oracle change detection (does structure/stack need re-scan?)
+ * Reads a filtered conversation transcript (produced by src/transcript-parser.ts)
+ * and extracts:
+ *   - Memories (feedback + patterns) — only direct user corrections or validated patterns
+ *   - Decisions (policies/rules/constraints that cannot be recovered from the diff)
+ *   - Safety rules (concrete command/path/branch rules from real incidents)
+ *   - Oracle change detection
+ *   - Handoff (session end state)
  *
- * Model: Sonnet (needs deeper understanding for decision extraction)
- * Budget: $0.30
+ * Model: Opus 4.6 (stronger rule-following for strict "default-is-nothing" prompt)
+ * Tools: Read, Grep, Glob (for de-dup verification against existing .axme-code/ storage).
+ *        NO Bash — prevents the auditor from reading live repo state and polluting
+ *        the handoff with the CURRENT state of the workspace instead of the
+ *        state at the end of the audited session.
+ * Budget: no cap (per project rule — see .axme-code/memory/feedback/no-llm-budget-caps.md)
  */
 
 import type { Memory, Decision, SessionHandoff } from "../types.js";
 import { extractCostFromResult, zeroCost, type CostInfo } from "../utils/cost-extractor.js";
 import { toMemorySlug } from "../storage/memory.js";
-import { toSlug } from "../storage/decisions.js";
+import { toSlug, listDecisions } from "../storage/decisions.js";
+import { listMemories } from "../storage/memory.js";
 
 export interface SessionAuditResult {
   memories: Memory[];
@@ -26,108 +33,181 @@ export interface SessionAuditResult {
   durationMs: number;
 }
 
-const AUDIT_PROMPT = `You are a session auditor. Analyze this coding session and extract everything useful for future sessions.
+const AUDIT_PROMPT = `You are auditing a Claude Code session transcript to extract ONLY knowledge that will be useful in FUTURE sessions and is NOT already available elsewhere.
 
-Extract ALL of the following categories. If a category has nothing to extract, output the section header with nothing inside.
+You have read-only tools available (Read, Grep, Glob). Use them ONLY to verify whether an extraction candidate already exists in project storage. DO NOT read live repo state (working tree, current src/ file contents for "what is there now"). Your job is to extract knowledge FROM THE TRANSCRIPT, not to describe the current state of the repo.
+
+The default answer for every category is "nothing". An empty section is the correct output for most sessions. Do not pad. Do not extract to look busy.
+
+==== YOUR VALIDATION WORKFLOW ====
+
+For EVERY candidate you consider extracting, run this check against .axme-code/ storage only:
+
+1. MEMORY candidate (feedback/pattern): Grep .axme-code/memory/ for the key phrase. If a similar memory exists, REJECT.
+2. DECISION candidate: Grep .axme-code/decisions/ for the key term. If already recorded, REJECT. Also verify the decision is a policy/principle/constraint that cannot be inferred by reading the diff that would result from this session (you do NOT need to read the actual diff — just ask yourself: "if someone reads the PR diff, can they recover this principle from the code alone?").
+3. SAFETY candidate: Grep .axme-code/safety/ to confirm it is new.
+
+Budget: read up to 15 files total. Reject fast. DO NOT read src/ or other repo code to verify candidates — that tells you what the repo looks like TODAY, not what was decided in this session. Trust the transcript for session events, use .axme-code/ only for dedup.
+
+HANDOFF SECTION NOTE: the handoff must describe the state AT THE END OF THE SESSION (based on the transcript), not the CURRENT state of the repo. Never read working tree or git status to fill handoff — those reflect later sessions, not this one.
+
+==== EXTRACTION CATEGORIES ====
+
+MEMORIES (type=feedback)
+Extract ONLY when the user explicitly corrected the agent, expressed a strong preference, or reacted negatively. Watch for: "don't", "stop", "always", "never", "no, wrong", user questioning agent's action, frustration, surprise. Also catch non-English equivalents (e.g. Russian "нельзя", "не надо", "всегда", "никогда", "неправильно", "сколько раз говорил").
+Required fields: what agent was doing, what user asked for instead, THE USER'S STATED REASON (if no reason was given, still extract but mark the Why as "user did not explain").
+
+MEMORIES (type=pattern)
+Extract ONLY when a non-obvious technique was discovered through trial and error AND the user explicitly validated it worked. NOT "we built feature X" — features are in the code.
+
+DECISIONS
+Extract ONLY if BOTH:
+(a) The decision is NOT visible in the resulting code/config/diff — someone reading the code cannot recover the reasoning or the rule.
+(b) The user explicitly stated it as a rule/policy/constraint in the transcript, OR the user agreed to a proposed rule/policy/constraint.
+
+REJECT:
+- "We added feature X because Y" — feature is in the code
+- "Use X instead of Y" — both visible in diff
+- "Changed approach from A to B" — git log has this
+- "User confirmed implementation Z" — implementation is in the code
+
+ACCEPT:
+- Process rules the user stated: "never merge without staging check"
+- Policy constraints: "no direct pushes to main"
+- Accepted trade-offs: "we accept this limitation for now"
+- Negative rules: "do not write to X"
+
+SAFETY
+Extract ONLY if a new bash_deny/bash_allow/fs_deny/git_protected_branch rule was produced from a real signal (user said so, or an incident happened in this session).
+
+HANDOFF
+Restate session state with specifics based on the transcript alone. This section does NOT require novelty.
+- stopped_at: exact task/file at end of session
+- in_progress: branch names, PR numbers, uncommitted work
+- blockers: concrete blockers with enough detail to resume
+- next: concrete next steps (file paths, commands)
+- dirty_branches: branch names with state
+
+==== OUTPUT LANGUAGE ====
+
+All output fields (title, description, keywords, body, reasoning, handoff fields) MUST be in English. Even if the transcript is in another language (Russian, etc.), write the extraction in English. Non-English user quotes may be embedded inline as evidence with quotation marks, but the surrounding explanation must be English. This is a hard requirement.
+
+==== OUTPUT FORMAT ====
+
+Use these exact markers. Empty sections MUST still include the header with nothing between markers.
 
 ###MEMORIES###
-For each error pattern (feedback) or successful approach (pattern):
-
 slug: <kebab-case, max 60 chars>
-type: <feedback or pattern>
-title: <one-line summary, max 80 chars>
-description: <1-2 sentence explanation>
-keywords: <3-7 keywords, comma-separated>
-scope: <project name, or "all" for universal>
-body: <explanation with **Why:** and **How to apply:**>
-
+type: <feedback | pattern>
+title: <English, max 80 chars>
+description: <English, 1-2 sentences>
+keywords: <English, 3-7 comma-separated>
+scope: <project name or "all">
+body: <English. Include **Why:** and **How to apply:** lines. Non-English quotes OK inline as evidence>
 ---
-
 ###END###
 
 ###DECISIONS###
-For each new architectural decision made or discovered:
-
-title: <short title, max 80 chars>
-decision: <what was decided, 1-3 sentences>
-reasoning: <why, 1-3 sentences>
-enforce: <required OR advisory OR none>
-
+title: <English, max 80 chars>
+decision: <English, what was decided>
+reasoning: <English, with specifics from the session>
+enforce: <required | advisory | none>
 ---
-
 ###END###
 
 ###SAFETY###
-For each new safety constraint discovered:
-
-rule_type: <bash_deny OR bash_allow OR fs_deny OR git_protected_branch>
-value: <the command/path/branch>
-
+rule_type: <bash_deny | bash_allow | fs_deny | git_protected_branch>
+value: <specific command/path/branch>
 ---
-
 ###END###
 
 ###ORACLE_CHANGES###
-Did the project structure or stack change significantly in this session?
-Answer YES or NO.
-If YES, briefly describe what changed (new directories, new dependencies, renamed files).
+YES or NO with 1 English sentence if YES
 ###END###
 
 ###HANDOFF###
-Summarize what the next session needs to know to continue this work:
-
-stopped_at: <what was the agent working on when session ended, or "nothing" if clean>
-in_progress: <what tasks/PRs/branches are mid-work, or "none">
-blockers: <any blockers or issues discovered, or "none">
-next: <concrete next steps, or "none">
-dirty_branches: <git branches with uncommitted or unpushed work, or "none">
+stopped_at: <English>
+in_progress: <English>
+blockers: <English>
+next: <English>
+dirty_branches: <English>
 ###END###
 
-Rules:
-- Only extract things useful in FUTURE sessions
-- Skip trivial or one-off issues
-- Be specific, not generic
-- For decisions: only real decisions with evidence, not guesses
-- For safety: only rules that should be enforced going forward
-- For oracle: YES only if structure/stack actually changed (new dirs, new deps, major refactors)
-
-===END===`;
+REMEMBER: Use your tools to verify every candidate before extracting. Empty is correct. All output English.`;
 
 /**
- * Run full session audit - extracts memories, decisions, safety rules, oracle changes.
+ * Build the "existing knowledge" context block that prevents duplicate extractions.
+ * We give the auditor a compact list of titles + short snippets so it can dedup
+ * without needing to Grep every file.
+ */
+function buildExistingContext(projectPath: string): string {
+  const parts: string[] = [];
+
+  try {
+    const decisions = listDecisions(projectPath);
+    if (decisions.length > 0) {
+      const lines = decisions.map(d => `- ${d.title}: ${d.decision.slice(0, 120)}`);
+      parts.push("## Existing decisions (DO NOT re-extract these)\n" + lines.join("\n"));
+    }
+  } catch {}
+
+  try {
+    const memories = listMemories(projectPath);
+    if (memories.length > 0) {
+      const lines = memories.map(m => `- [${m.type}] ${m.title}: ${m.description}`);
+      parts.push("## Existing memories (DO NOT re-extract these)\n" + lines.join("\n"));
+    }
+  } catch {}
+
+  return parts.join("\n\n");
+}
+
+/**
+ * Run full session audit — extracts memories, decisions, safety rules, oracle changes, handoff.
+ *
+ * @param opts.sessionTranscript - Filtered conversation text from a Claude Code
+ *   transcript (see transcript-parser.ts). Preferred input.
+ * @param opts.sessionEvents - Fallback: worklog events joined as text. Used when
+ *   no Claude Code transcript is attached to the session.
  */
 export async function runSessionAudit(opts: {
   sessionId: string;
-  sessionEvents: string;
+  sessionTranscript?: string;
+  sessionEvents?: string;
   filesChanged: string[];
   projectPath: string;
-  oracleSummary?: string;
-  decisionsCount?: number;
 }): Promise<SessionAuditResult> {
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   const startTime = Date.now();
 
   const queryOpts = {
     cwd: opts.projectPath,
-    model: "claude-sonnet-4-6",
-    maxBudgetUsd: 0.30,
+    model: "claude-opus-4-6",
     permissionMode: "bypassPermissions" as const,
     allowDangerouslySkipPermissions: true,
-    allowedTools: [] as string[],
-    disallowedTools: ["Write", "Edit", "Bash", "Glob", "Grep", "Read", "Agent", "NotebookEdit", "Skill", "TodoWrite"],
+    allowedTools: ["Read", "Grep", "Glob"],
+    disallowedTools: ["Write", "Edit", "NotebookEdit", "Agent", "Skill", "TodoWrite", "WebFetch", "WebSearch", "Bash"],
   };
+
+  const existingContext = buildExistingContext(opts.projectPath);
+  const conversationSource = opts.sessionTranscript ?? opts.sessionEvents ?? "";
+  const conversationLabel = opts.sessionTranscript
+    ? "==== SESSION TRANSCRIPT (filtered conversation) ===="
+    : "==== SESSION WORKLOG EVENTS (transcript unavailable) ====";
 
   const contextLines = [
     AUDIT_PROMPT,
     "",
-    `Session ID: ${opts.sessionId}`,
-    `Files changed (${opts.filesChanged.length}): ${opts.filesChanged.slice(0, 30).join(", ")}`,
-    opts.oracleSummary ? `Current oracle summary: ${opts.oracleSummary}` : "",
-    opts.decisionsCount !== undefined ? `Current decisions: ${opts.decisionsCount}` : "",
+    "==== EXISTING PROJECT KNOWLEDGE (verify your extractions are NEW vs this) ====",
     "",
-    "Session transcript:",
-    opts.sessionEvents,
-  ].filter(Boolean);
+    existingContext || "(none)",
+    "",
+    `Files changed in this session (${opts.filesChanged.length}): ${opts.filesChanged.slice(0, 30).join(", ")}`,
+    "",
+    conversationLabel,
+    "",
+    conversationSource,
+  ];
 
   const q = sdk.query({ prompt: contextLines.join("\n"), options: queryOpts });
 

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,7 +1,9 @@
 /**
  * PostToolUse hook - runs after Edit/Write tool calls.
  *
- * Tracks filesChanged in session metadata.
+ * Tracks filesChanged in session metadata, and attaches the Claude Code
+ * session (session_id + transcript_path from the hook event) to the current
+ * AXME session so the LLM auditor can later read the full transcript.
  *
  * Input: JSON on stdin from Claude Code hooks system.
  * Workspace path: passed via --workspace flag (hardcoded at setup time).
@@ -10,7 +12,7 @@
  * NOT from Claude Code's session_id (which is a different ID).
  */
 
-import { trackFileChanged } from "../storage/sessions.js";
+import { trackFileChanged, attachClaudeSession } from "../storage/sessions.js";
 import { readActiveSession } from "../storage/sessions.js";
 import { pathExists } from "../storage/engine.js";
 import { join } from "node:path";
@@ -19,22 +21,38 @@ import { AXME_CODE_DIR } from "../types.js";
 interface HookInput {
   tool_name: string;
   tool_input: Record<string, any>;
+  session_id?: string;
+  transcript_path?: string;
 }
 
 function handlePostToolUse(workspacePath: string, event: HookInput): void {
   const { tool_name, tool_input } = event;
 
-  if (!["Edit", "Write", "NotebookEdit"].includes(tool_name)) return;
   if (!pathExists(join(workspacePath, AXME_CODE_DIR))) return;
+
+  const axmeSessionId = readActiveSession(workspacePath);
+  if (!axmeSessionId) return;
+
+  // Attach Claude session on every tool call (dedup'd by id inside the
+  // storage helper). We do this on every call and not only on Edit/Write
+  // because the very first hook event of the session may be a different
+  // tool type.
+  if (event.session_id && event.transcript_path) {
+    attachClaudeSession(workspacePath, axmeSessionId, {
+      id: event.session_id,
+      transcriptPath: event.transcript_path,
+      role: "main",
+    });
+  }
+
+  // filesChanged tracking only for mutation tools
+  if (!["Edit", "Write", "NotebookEdit"].includes(tool_name)) return;
 
   const filePath = tool_input.file_path || tool_input.path;
   if (!filePath || typeof filePath !== "string") return;
   if (filePath.includes(AXME_CODE_DIR)) return;
 
-  const sessionId = readActiveSession(workspacePath);
-  if (sessionId) {
-    trackFileChanged(workspacePath, sessionId, filePath);
-  }
+  trackFileChanged(workspacePath, axmeSessionId, filePath);
 }
 
 /**

--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -12,6 +12,7 @@
 
 import { loadSafetyRules, checkBash, checkGit, checkFilePath } from "../storage/safety.js";
 import { pathExists } from "../storage/engine.js";
+import { attachClaudeSession, readActiveSession } from "../storage/sessions.js";
 import { join } from "node:path";
 import { AXME_CODE_DIR } from "../types.js";
 import type { SafetyVerdict } from "../storage/safety.js";
@@ -19,6 +20,8 @@ import type { SafetyVerdict } from "../storage/safety.js";
 interface HookInput {
   tool_name: string;
   tool_input: Record<string, any>;
+  session_id?: string;
+  transcript_path?: string;
 }
 
 /**
@@ -72,6 +75,22 @@ function handlePreToolUse(workspacePath: string, event: HookInput): void {
   const { tool_name, tool_input } = event;
 
   if (!pathExists(join(workspacePath, AXME_CODE_DIR))) return;
+
+  // Attach Claude Code session (id + transcript path) to the current AXME
+  // session on every tool call. Dedup'd by id inside the storage helper, so
+  // repeated calls are cheap. We do this in PreToolUse (rather than only in
+  // PostToolUse) so the attachment happens before any safety denial — we
+  // want the audit trail even for blocked tools.
+  if (event.session_id && event.transcript_path) {
+    const axmeSessionId = readActiveSession(workspacePath);
+    if (axmeSessionId) {
+      attachClaudeSession(workspacePath, axmeSessionId, {
+        id: event.session_id,
+        transcriptPath: event.transcript_path,
+        role: "main",
+      });
+    }
+  }
 
   const rules = loadSafetyRules(workspacePath);
   let verdict: SafetyVerdict = { allowed: true };

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -15,16 +15,35 @@
  */
 
 import { join } from "node:path";
-import { readActiveSession } from "../storage/sessions.js";
+import { readActiveSession, attachClaudeSession } from "../storage/sessions.js";
 import { runSessionCleanup } from "../session-cleanup.js";
 import { pathExists } from "../storage/engine.js";
 import { AXME_CODE_DIR } from "../types.js";
 
-async function handleSessionEnd(workspacePath: string): Promise<void> {
+interface SessionEndInput {
+  session_id?: string;
+  transcript_path?: string;
+  source?: string;
+}
+
+async function handleSessionEnd(workspacePath: string, input: SessionEndInput): Promise<void> {
   if (!pathExists(join(workspacePath, AXME_CODE_DIR))) return;
 
   const sessionId = readActiveSession(workspacePath);
   if (!sessionId) return;
+
+  // If Claude Code passes session_id + transcript_path in the SessionEnd
+  // event, make sure it is attached before the audit runs. PreToolUse
+  // should already have done this during the session, but a session that
+  // only had read-only MCP tool calls (no Edit/Write, no PreToolUse-matched
+  // tools) might not have been attached yet.
+  if (input.session_id && input.transcript_path) {
+    attachClaudeSession(workspacePath, sessionId, {
+      id: input.session_id,
+      transcriptPath: input.transcript_path,
+      role: "main",
+    });
+  }
 
   await runSessionCleanup(workspacePath, sessionId, { clearActive: true });
 }
@@ -37,10 +56,15 @@ export async function runSessionEndHook(workspacePath?: string): Promise<void> {
   if (!workspacePath) return;
 
   try {
-    // Still consume stdin (Claude Code sends it), but we don't need its content
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) chunks.push(chunk);
-    await handleSessionEnd(workspacePath);
+    let input: SessionEndInput = {};
+    try {
+      input = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as SessionEndInput;
+    } catch {
+      // Empty/invalid stdin is fine — we'll proceed without transcript attachment
+    }
+    await handleSessionEnd(workspacePath, input);
   } catch {
     // Hook failures must be silent
   }

--- a/src/session-cleanup.ts
+++ b/src/session-cleanup.ts
@@ -13,9 +13,9 @@
 import { join } from "node:path";
 import { readWorklog, logSessionEnd } from "./storage/worklog.js";
 import { saveMemories } from "./storage/memory.js";
-import { addDecision, listDecisions } from "./storage/decisions.js";
+import { addDecision } from "./storage/decisions.js";
 import { updateSafetyRule } from "./storage/safety.js";
-import { writeOracleFiles, oracleContext } from "./storage/oracle.js";
+import { writeOracleFiles } from "./storage/oracle.js";
 import { writeHandoff } from "./storage/plans.js";
 import {
   closeSession,
@@ -25,6 +25,7 @@ import {
   readActiveSession,
 } from "./storage/sessions.js";
 import { pathExists } from "./storage/engine.js";
+import { parseAndRenderTranscripts } from "./transcript-parser.js";
 import { AXME_CODE_DIR } from "./types.js";
 
 export interface SessionCleanupResult {
@@ -89,32 +90,47 @@ export async function runSessionCleanup(
 
   const filesChanged = session.filesChanged ?? [];
 
-  const events = readWorklog(workspacePath, { limit: 500 });
-  const sessionEvents = events
-    .filter(e => e.sessionId === sessionId)
-    .reverse()
-    .map(e => `[${e.timestamp}] ${e.type}: ${JSON.stringify(e.data)}`)
-    .join("\n");
+  // Prefer the Claude Code transcript (filtered conversation) over the worklog
+  // when available. Transcripts contain the actual user/assistant dialog with
+  // reasoning, corrections, and agreements — exactly what the auditor needs.
+  // The worklog only has sparse structural events (session_start, memory_saved, etc).
+  const claudeSessions = session.claudeSessions ?? [];
+  let sessionTranscript: string | undefined;
+  if (claudeSessions.length > 0) {
+    const parsed = parseAndRenderTranscripts(claudeSessions);
+    if (parsed.rendered.length > 0) {
+      sessionTranscript = parsed.rendered;
+    }
+  }
+
+  // Fallback: if no transcript is attached (pre-transcript-audit sessions, or
+  // a session that ended before any hook fired), use the worklog events.
+  let sessionEvents: string | undefined;
+  if (!sessionTranscript) {
+    const events = readWorklog(workspacePath, { limit: 500 });
+    sessionEvents = events
+      .filter(e => e.sessionId === sessionId)
+      .reverse()
+      .map(e => `[${e.timestamp}] ${e.type}: ${JSON.stringify(e.data)}`)
+      .join("\n");
+  }
 
   const result: SessionCleanupResult = { ...base };
   let auditSucceeded = false;
-  const hasActivity = sessionEvents.length > 50;
+  const activityLength = (sessionTranscript ?? sessionEvents ?? "").length;
+  const hasActivity = activityLength > 50;
 
   // Run LLM audit only if there's meaningful activity to analyze
   if (hasActivity) {
     try {
       const { runSessionAudit } = await import("./agents/session-auditor.js");
 
-      const oracleSummary = oracleContext(workspacePath).slice(0, 500);
-      const decisionsCount = listDecisions(workspacePath).length;
-
       const audit = await runSessionAudit({
         sessionId,
+        sessionTranscript,
         sessionEvents,
         filesChanged,
         projectPath: workspacePath,
-        oracleSummary,
-        decisionsCount,
       });
 
       if (audit.memories.length > 0) saveMemories(workspacePath, audit.memories);

--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { readdirSync, readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { ensureDir, writeJson, readJson, pathExists, atomicWrite, removeFile, readSafe } from "./engine.js";
-import type { SessionMeta } from "../types.js";
+import type { SessionMeta, ClaudeSessionRef } from "../types.js";
 import { AXME_CODE_DIR } from "../types.js";
 
 const SESSIONS_DIR = "sessions";
@@ -178,6 +178,39 @@ export function trackFileChanged(projectPath: string, sessionId: string, filePat
     session.filesChanged.push(filePath);
     writeSession(projectPath, session);
   }
+}
+
+/**
+ * Attach a Claude Code session (from a hook event) to an AXME session.
+ *
+ * Called from hooks on every tool call. The first call records the Claude
+ * Code session_id and transcript path; subsequent calls are dedup'd by id.
+ *
+ * The session auditor uses this list to locate transcript files for the
+ * audit. Multi-agent scenarios (tester, reviewer) will attach additional
+ * Claude sessions to the same AXME session via the same mechanism.
+ *
+ * Silent no-op if the session cannot be read — the MCP server may be mid-
+ * shutdown or the meta file may be under concurrent write.
+ */
+export function attachClaudeSession(
+  projectPath: string,
+  axmeSessionId: string,
+  ref: { id: string; transcriptPath: string; role?: string },
+): void {
+  if (!ref.id || !ref.transcriptPath) return;
+  const session = loadSession(projectPath, axmeSessionId);
+  if (!session) return;
+  if (!session.claudeSessions) session.claudeSessions = [];
+  if (session.claudeSessions.some(c => c.id === ref.id)) return;
+  const entry: ClaudeSessionRef = {
+    id: ref.id,
+    transcriptPath: ref.transcriptPath,
+    firstSeen: new Date().toISOString(),
+    ...(ref.role ? { role: ref.role } : {}),
+  };
+  session.claudeSessions.push(entry);
+  writeSession(projectPath, session);
 }
 
 export function incrementTurns(projectPath: string, sessionId: string): void {

--- a/src/transcript-parser.ts
+++ b/src/transcript-parser.ts
@@ -1,0 +1,243 @@
+/**
+ * Claude Code transcript parser and filter for the session auditor.
+ *
+ * Claude Code stores every session as a jsonl file at
+ *   ~/.claude/projects/<encoded-path>/<session-id>.jsonl
+ *
+ * The raw file is large (often 1-2 MB) and ~90% of it is tool_result blocks:
+ * bash outputs, file reads, grep matches, etc. The session auditor does not
+ * need those — they describe WHAT the code did, which the auditor can see
+ * from the code itself and from the diff. What the auditor needs is the
+ * CONVERSATION: user corrections, assistant reasoning, assistant findings.
+ *
+ * This parser drops everything except:
+ *   - user text messages (real ones, not IDE notifications)
+ *   - assistant text messages >= 80 chars (drops pure transitions)
+ *   - assistant thinking blocks
+ *   - assistant tool_use blocks (compact form: [ToolName: short params])
+ *
+ * Typical reduction: 1.4 MB raw → 65 KB filtered (~4%).
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+
+export interface ConversationTurn {
+  role: "user" | "assistant";
+  kind: "text" | "thinking" | "tool_use";
+  content: string;
+}
+
+export interface ParsedTranscript {
+  turns: ConversationTurn[];
+  rendered: string;
+  rawSize: number;
+  filteredSize: number;
+  userTurns: number;
+  assistantTurns: number;
+  thinkingTurns: number;
+  toolUseTurns: number;
+}
+
+/** Minimum length for assistant text blocks to keep. Shorter is considered a pure transition. */
+const MIN_ASSISTANT_TEXT_LENGTH = 80;
+
+/** Maximum characters of tool input to embed inline. */
+const TOOL_INPUT_MAX = 200;
+
+/**
+ * Render a tool_use block as a compact string for the auditor.
+ * We deliberately drop the tool result (it is the 90% of raw transcript).
+ */
+function shortenToolInput(name: string, input: any): string {
+  if (!input || typeof input !== "object") return "";
+  switch (name) {
+    case "Edit":
+    case "Write":
+    case "Read":
+    case "NotebookEdit":
+      return input.file_path || input.path || "";
+    case "Bash":
+      return String(input.command || "").slice(0, TOOL_INPUT_MAX);
+    case "Glob":
+      return input.pattern || "";
+    case "Grep":
+      return `"${String(input.pattern || "").slice(0, 100)}"${input.path ? ` in ${input.path}` : ""}`;
+    case "WebFetch":
+    case "WebSearch":
+      return input.url || input.query || "";
+    case "TodoWrite":
+      return `${(input.todos || []).length} todos`;
+    default: {
+      const keys = Object.keys(input).slice(0, 3);
+      const pairs = keys.map(k => {
+        const v = input[k];
+        const s = typeof v === "string" ? v.slice(0, 50) : JSON.stringify(v).slice(0, 50);
+        return `${k}=${s}`;
+      });
+      return pairs.join(" ");
+    }
+  }
+}
+
+/**
+ * Parse a Claude Code transcript jsonl file into filtered conversation turns.
+ * Returns empty turns array if the file does not exist or cannot be read.
+ */
+export function parseTranscript(path: string): ConversationTurn[] {
+  if (!existsSync(path)) return [];
+
+  let content: string;
+  try {
+    content = readFileSync(path, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const turns: ConversationTurn[] = [];
+  const lines = content.split("\n").filter(Boolean);
+
+  for (const line of lines) {
+    let event: any;
+    try { event = JSON.parse(line); } catch { continue; }
+
+    const msg = event.message;
+    if (!msg || !Array.isArray(msg.content)) continue;
+    const role = msg.role;
+    if (role !== "user" && role !== "assistant") continue;
+
+    for (const block of msg.content) {
+      const btype = block.type;
+
+      // USER text: drop IDE notifications and system reminders
+      if (role === "user" && btype === "text") {
+        const text = String(block.text || "").trim();
+        if (!text) continue;
+        if (text.startsWith("<ide_opened_file>")) continue;
+        if (text.startsWith("<ide_selection>")) continue;
+        if (text.startsWith("<system-reminder>")) continue;
+        if (text.startsWith("<command-name>")) continue;
+        if (text.startsWith("<command-message>")) continue;
+        if (text.startsWith("Caveat:")) continue;
+        turns.push({ role: "user", kind: "text", content: text });
+      }
+
+      // ASSISTANT text: keep only substantial messages
+      if (role === "assistant" && btype === "text") {
+        const text = String(block.text || "").trim();
+        if (text.length < MIN_ASSISTANT_TEXT_LENGTH) continue;
+        turns.push({ role: "assistant", kind: "text", content: text });
+      }
+
+      // ASSISTANT thinking: keep all (critical signal for handoff and reasoning)
+      if (role === "assistant" && btype === "thinking") {
+        const text = String(block.thinking || "").trim();
+        if (!text) continue;
+        turns.push({ role: "assistant", kind: "thinking", content: text });
+      }
+
+      // ASSISTANT tool_use: compact form, NO tool results
+      if (role === "assistant" && btype === "tool_use") {
+        const name = String(block.name || "unknown");
+        const shortInput = shortenToolInput(name, block.input);
+        turns.push({
+          role: "assistant",
+          kind: "tool_use",
+          content: `[${name}${shortInput ? ": " + shortInput : ""}]`,
+        });
+      }
+    }
+  }
+
+  return turns;
+}
+
+/**
+ * Render filtered conversation turns into a compact text format for the LLM.
+ * Consecutive tool_use blocks from the assistant are coalesced into one line.
+ */
+export function renderConversation(turns: ConversationTurn[]): string {
+  const lines: string[] = [];
+  let currentRole: string | null = null;
+  let toolBuffer: string[] = [];
+
+  const flushToolBuffer = () => {
+    if (toolBuffer.length > 0) {
+      lines.push(`  tools: ${toolBuffer.join(" ")}`);
+      toolBuffer = [];
+    }
+  };
+
+  for (const turn of turns) {
+    if (turn.kind === "tool_use") {
+      toolBuffer.push(turn.content);
+      continue;
+    }
+    flushToolBuffer();
+
+    if (turn.role !== currentRole) {
+      lines.push("");
+      currentRole = turn.role;
+    }
+
+    if (turn.kind === "thinking") {
+      lines.push(`[ASSISTANT thinking] ${turn.content}`);
+    } else if (turn.kind === "text") {
+      const tag = turn.role === "user" ? "USER" : "ASSISTANT";
+      lines.push(`[${tag}] ${turn.content}`);
+    }
+  }
+  flushToolBuffer();
+
+  return lines.join("\n");
+}
+
+/**
+ * Parse a transcript file, filter it, render it, and return stats.
+ * Convenience wrapper used by the session auditor.
+ */
+export function parseAndRenderTranscript(path: string): ParsedTranscript {
+  const turns = parseTranscript(path);
+  const rendered = renderConversation(turns);
+
+  let rawSize = 0;
+  try { rawSize = readFileSync(path, "utf-8").length; } catch {}
+
+  return {
+    turns,
+    rendered,
+    rawSize,
+    filteredSize: rendered.length,
+    userTurns: turns.filter(t => t.role === "user" && t.kind === "text").length,
+    assistantTurns: turns.filter(t => t.role === "assistant" && t.kind === "text").length,
+    thinkingTurns: turns.filter(t => t.kind === "thinking").length,
+    toolUseTurns: turns.filter(t => t.kind === "tool_use").length,
+  };
+}
+
+/**
+ * Parse and render multiple transcripts (for multi-agent sessions), joining
+ * them with role labels so the auditor can distinguish which agent said what.
+ */
+export function parseAndRenderTranscripts(
+  refs: Array<{ id: string; transcriptPath: string; role?: string }>,
+): { rendered: string; totalRaw: number; totalFiltered: number } {
+  if (refs.length === 0) return { rendered: "", totalRaw: 0, totalFiltered: 0 };
+  if (refs.length === 1) {
+    const parsed = parseAndRenderTranscript(refs[0].transcriptPath);
+    return { rendered: parsed.rendered, totalRaw: parsed.rawSize, totalFiltered: parsed.filteredSize };
+  }
+
+  const parts: string[] = [];
+  let totalRaw = 0;
+  let totalFiltered = 0;
+  for (const ref of refs) {
+    const parsed = parseAndRenderTranscript(ref.transcriptPath);
+    if (parsed.rendered.length === 0) continue;
+    parts.push(`==== AGENT: ${ref.role ?? "main"} (session ${ref.id}) ====`);
+    parts.push(parsed.rendered);
+    parts.push("");
+    totalRaw += parsed.rawSize;
+    totalFiltered += parsed.filteredSize;
+  }
+  return { rendered: parts.join("\n"), totalRaw, totalFiltered };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,22 @@ export interface WorklogEvent {
 
 // --- Session ---
 
+/**
+ * A Claude Code (or future multi-agent) session attached to an AXME session.
+ * One AXME session can have multiple attached Claude Code sessions when
+ * tester/reviewer sub-agents join in later phases.
+ */
+export interface ClaudeSessionRef {
+  /** Claude Code's own session_id (from hook event input) */
+  id: string;
+  /** Absolute path to the Claude Code transcript jsonl file */
+  transcriptPath: string;
+  /** ISO timestamp when this Claude session was first seen in a hook event */
+  firstSeen: string;
+  /** Role in the AXME session. Defaults to "main". Reserved for future multi-agent. */
+  role?: string;
+}
+
 export interface SessionMeta {
   id: string;
   createdAt: string;
@@ -165,6 +181,8 @@ export interface SessionMeta {
   pid?: number;
   /** ISO timestamp when LLM session audit completed. Used to dedupe auto-audit vs startup fallback. */
   auditedAt?: string;
+  /** Claude Code sessions attached to this AXME session (populated by hooks). */
+  claudeSessions?: ClaudeSessionRef[];
 }
 
 // --- Config ---

--- a/src/utils/agent-options.ts
+++ b/src/utils/agent-options.ts
@@ -32,7 +32,6 @@ const ROLE_TOOLS: Record<AgentRole, { allowed: string[]; disallowed: string[] }>
 export function buildAgentQueryOptions(base: {
   cwd: string;
   model: string;
-  budgetUsd?: number;
   maxTurns?: number;
   agentPrompt?: string;
 }, role: AgentRole): Options {
@@ -45,7 +44,6 @@ export function buildAgentQueryOptions(base: {
       ? { type: "preset" as const, preset: "claude_code" as const, append: base.agentPrompt }
       : { type: "preset" as const, preset: "claude_code" as const },
     settingSources: ["project"],
-    ...(base.budgetUsd !== undefined ? { maxBudgetUsd: base.budgetUsd } : {}),
     ...(base.maxTurns !== undefined ? { maxTurns: base.maxTurns } : {}),
     permissionMode: "bypassPermissions",
     allowDangerouslySkipPermissions: true,


### PR DESCRIPTION
## Summary

The session auditor previously ran on worklog events (session_start, memory_saved, etc.) which contain almost none of what actually happened. The audit guessed from filesChanged alone and extracted meta-knowledge about the code instead of real user feedback - producing storage-module junk.

This PR rewires the audit to read the actual Claude Code transcript (jsonl conversation file), filter it down to real signal, and run extraction with stricter rules.

## Changes

### Transcript-based audit pipeline
- New `ClaudeSessionRef` on `SessionMeta` + `attachClaudeSession()` helper. Hooks read `session_id` and `transcript_path` from Claude Code's hook event stdin (which we were discarding before) and attach them to the current AXME session. Field is a list to support future multi-agent (tester, reviewer sub-agents).
- Attach happens in PreToolUse, PostToolUse, and SessionEnd.
- New `src/transcript-parser.ts` filters the raw jsonl (1-2 MB per session) down to the actual conversation (~4% of raw). Keeps user text, assistant text >=80 chars, thinking blocks, compact tool_use lines. Drops tool results, IDE notifications, system reminders.
- `session-cleanup.ts` prefers the filtered transcript over the worklog when available. Worklog is kept as fallback.

### Audit prompt and model
- Upgraded Sonnet -> Opus 4.6. Strict 'default is nothing' rules are followed more reliably.
- Audit agent now has Read/Grep/Glob tools but **NOT Bash**. This was the critical fix for handoff drift: a Bash-enabled auditor naturally runs \`git status\` and reports the CURRENT state of the workspace into the handoff, which is wrong - handoff must reflect the end of the audited session.
- Prompt rewritten with explicit REJECT/ACCEPT examples for decisions, English output requirement (with non-English quotes embedded inline as evidence).
- Existing decisions and memories are passed into the prompt as 'do not re-extract these' context.

### Side cleanup
- Removed \`budgetUsd\` / \`maxBudgetUsd\` from every agent (scanners, memory extractor, session auditor, buildAgentQueryOptions). Budget caps truncate LLM output mid-task and pollute storage modules with low-quality artifacts.

## Dry-run results

Validated on transcripts 0d770f0c (1.4 MB, 13 user turns) and 1df5d43d (926 KB, 7 user turns) before committing.

| Metric | Old (Sonnet + worklog) | New (Opus + transcript) |
|---|---|---|
| False-positive memories | 2-3 per session | 0 per session |
| False-positive decisions | 3-5 per session | 0-1 per session |
| Memory quality | generic meta-knowledge | user corrections with inline evidence quotes |
| Handoff drift | significant | none |
| Language | mixed | English + inline quotes |
| Cost per session | \$0.11-0.12 | \$0.48-0.66 |

Cost is 4-6x higher but quality is the difference between usable and unusable storage entries.

## Test plan (manual, post-merge)

- [ ] Restart VS Code / Claude Code so new MCP server picks up the build
- [ ] Make a few tool calls in a fresh session, then close VS Code
- [ ] Reopen VS Code and check:
  - [ ] Previous session's \`meta.json\` has \`claudeSessions\` populated with id + transcriptPath
  - [ ] \`auditedAt\` is set
  - [ ] \`.axme-code/plans/handoff.md\` was created
  - [ ] Extracted memories (if any) are in English, without meta-knowledge about the code
  - [ ] Extracted decisions (if any) are real policies not visible in the diff
  - [ ] Handoff reflects what was actually done in that session (not today's state)
- [ ] Verify a session with only read-only MCP tool calls also gets audited (SessionEnd hook attaches the transcript as a safety net)

## Not in this PR

- Multi-agent auditor variant. \`claudeSessions\` field supports it, but exercising requires the tester/reviewer agent work.
- Worklog enrichment. Transcript covers the same need more reliably.