### PR TITLE
fix: init-scan dedup — preset decisions visible to LLM scanner

### DIFF
--- a/src/agents/scanners/decision.ts
+++ b/src/agents/scanners/decision.ts
@@ -91,11 +91,17 @@ Find ALL decisions you can find evidence for. Do not limit the number. Cover all
 Do NOT include:
 - Trivial/obvious decisions ("project uses git", "has tests")
 - Decisions you're guessing about with no evidence
-- Duplicate decisions (if "uses PostgreSQL" and "uses SQLAlchemy" are the same decision, combine them)`;
+- Duplicate decisions (if "uses PostgreSQL" and "uses SQLAlchemy" are the same decision, combine them)
+
+CRITICAL DEDUP: If <existing_decisions> is provided below, it lists decisions already stored for this project (e.g. from presets). Do NOT extract any decision covering the SAME TOPIC as an existing one — even with different wording. Same topic = skip.
+Examples: existing "All changes to main via PR" → skip "PR-only merges with checks". Existing "No destructive git ops" → skip "Never force-push".
+If your version adds genuinely new details the existing lacks, extract it and note which existing ID it would supersede.`;
 
 export async function runDecisionScan(opts: {
   projectPath: string;
   model?: string;
+  /** Existing decisions (e.g. from presets) — scanner skips same-topic. */
+  existingDecisions?: Decision[];
 }): Promise<DecisionScanResult> {
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   const startTime = Date.now();
@@ -106,7 +112,15 @@ export async function runDecisionScan(opts: {
     "scanner",
   );
 
-  const q = sdk.query({ prompt: DECISION_SCAN_PROMPT, options: queryOpts });
+  let prompt = DECISION_SCAN_PROMPT;
+  if (opts.existingDecisions && opts.existingDecisions.length > 0) {
+    const list = opts.existingDecisions.map(d =>
+      `- ${d.id}: ${d.title} [${d.enforce ?? "info"}] — ${d.decision}`
+    ).join("\n");
+    prompt += `\n\n<existing_decisions>\n${list}\n</existing_decisions>`;
+  }
+
+  const q = sdk.query({ prompt, options: queryOpts });
 
   let result = "";
   let cost: CostInfo | undefined;

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -137,10 +137,11 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
       const { runOracleScan } = await import("../agents/scanners/oracle.js");
       return { type: "oracle" as const, result: await runOracleScan({ projectPath, workspaceMode: opts?.workspaceMode }) };
     })(),
-    // Decision scan
+    // Decision scan — pass existing decisions (from presets) so scanner skips same-topic
     (async () => {
       const { runDecisionScan } = await import("../agents/scanners/decision.js");
-      return { type: "decision" as const, result: await runDecisionScan({ projectPath }) };
+      const existing = listDecisions(projectPath);
+      return { type: "decision" as const, result: await runDecisionScan({ projectPath, existingDecisions: existing }) };
     })(),
     // Safety scan
     (async () => {


### PR DESCRIPTION
## Problem

axme-code setup creates ~200 duplicate decisions across 57 repos. Root cause: preset-seed phase creates 13 generic decisions (D-001..D-013), then init-scan LLM extracts specific decisions without knowing presets exist. Same-topic rules get different wording and different IDs.

## Fix

- `runDecisionScan` now accepts `existingDecisions` parameter
- `initProjectWithLLM` passes `listDecisions(projectPath)` after preset apply
- Scanner prompt includes `<existing_decisions>` context with explicit dedup rules
- LLM skips same-topic extractions, or marks them for supersede if genuinely more specific

## Verification

- 119/119 full storage audit PASS
- audit-kb --all-repos confirmed the pattern: 201 superseded decisions were preset vs init-scan dupes