### PR TITLE
feat: enriched handoff + axme_close_session

### DIFF
--- a/src/agents/session-auditor.ts
+++ b/src/agents/session-auditor.ts
@@ -225,9 +225,12 @@ SAFETY
 Requires USER CONFIRMATION (see above). Extract ONLY if the user explicitly mandated a new bash_deny/bash_allow/fs_deny/git_protected_branch rule ("agent must never run X", "block writes to Y", "main branch is protected from force push"). An incident happening in the session is NOT enough by itself — incidents go to the worklog, not to safety rules. Safety rules persist forever and must come from explicit user mandate.
 
 HANDOFF
-Restate session state with specifics based on the transcript alone. This section does NOT require novelty.
+Restate session state with specifics based on the transcript alone. This section does NOT require novelty. This is what the NEXT agent session will see as context, so be specific enough to resume work.
 - stopped_at: exact task/file at end of session
+- summary: 2-5 bullet points of what was accomplished (PRs, merges, fixes, deploys). Include PR numbers and URLs if visible in transcript.
 - in_progress: branch names, PR numbers, uncommitted work
+- prs: list of PRs touched in this session, format "url | title | status" per line (status: open/merged/closed)
+- test_results: summary of test runs if any (e.g. "119/119 pass, 12/12 chain-bypass pass")
 - blockers: concrete blockers with enough detail to resume
 - next: concrete next steps (file paths, commands)
 - dirty_branches: branch names with state
@@ -333,7 +336,10 @@ If no questions, leave this section empty (just the marker, no entries).
 
 ###HANDOFF###
 stopped_at: <English>
+summary: <English, 2-5 bullet points>
 in_progress: <English>
+prs: <one per line: url | title | status>
+test_results: <English, or "none">
 blockers: <English>
 next: <English>
 dirty_branches: <English>
@@ -966,18 +972,35 @@ export function parseAuditOutput(output: string, sessionId: string): Omit<Sessio
     }
   }
 
-  // Parse handoff
+  // Parse handoff (enriched format with backward compat)
   let handoff: SessionHandoff | null = null;
   const handoffSection = extractSection(output, "HANDOFF");
   if (handoffSection) {
     const stoppedAt = getField(handoffSection, "stopped_at");
+    const summary = getField(handoffSection, "summary");
     const inProgress = getField(handoffSection, "in_progress");
+    const prsRaw = getField(handoffSection, "prs");
+    const testResults = getField(handoffSection, "test_results");
     const blockers = getField(handoffSection, "blockers");
     const next = getField(handoffSection, "next");
     const dirtyBranches = getField(handoffSection, "dirty_branches");
+    // Parse PRs: "url | title | status" per line
+    const prs: Array<{ url: string; title: string; status: string }> = [];
+    if (prsRaw) {
+      for (const line of prsRaw.split("\n")) {
+        const parts = line.split("|").map(s => s.trim());
+        if (parts.length >= 3) prs.push({ url: parts[0], title: parts[1], status: parts[2] });
+      }
+    }
     const hasContent = [stoppedAt, inProgress, next].some(v => v && v !== "none" && v !== "nothing");
     if (hasContent) {
-      handoff = { stoppedAt, inProgress, blockers, next, dirtyBranches };
+      handoff = {
+        stoppedAt, inProgress, blockers, next, dirtyBranches,
+        summary: summary || undefined,
+        testResults: (testResults && testResults !== "none") ? testResults : undefined,
+        prs: prs.length > 0 ? prs : undefined,
+        source: "auditor",
+      };
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -133,6 +133,7 @@ function buildInstructions(): string {
     parts.push("Call axme_context at session start to load project knowledge base.");
   }
   parts.push("Save memories, decisions, and safety rules immediately when discovered during work.");
+  parts.push("SESSION CLOSE: when the user asks to close/end the session (any language), call axme_close_session with a detailed handoff and startup text. Then output the startup text to the user in chat for copy-paste into the next session.");
   parts.push("DECISION CONFLICT RULE: if two active decisions contradict each other, treat the NEWER one (by date) as authoritative. The older one is a candidate for supersede at next audit.");
   parts.push(
     `STORAGE ROOT: ${defaultProjectPath}/.axme-code — for any direct inspection of .axme-code/ files via Bash (ls, cat, grep, find), use this ABSOLUTE path. Do NOT use relative paths from your cwd; in a multi-repo workspace your cwd may point to a child repo with its own separate .axme-code/ storage. Every session's meta.json also contains an "origin" field with its absolute parent directory — read it to verify which storage a given session belongs to.`,
@@ -392,6 +393,79 @@ server.tool(
     const q = answerQuestion(pp(project_path), question_id, answer);
     if (!q) return { content: [{ type: "text" as const, text: `Question ${question_id} not found or not open.` }] };
     return { content: [{ type: "text" as const, text: `Answer recorded for ${q.id}. Status: [answered]` }] };
+  },
+);
+
+// --- axme_close_session ---
+server.tool(
+  "axme_close_session",
+  "Explicitly close the current session with a detailed handoff. Call when the user says 'close session' / 'end session' / 'закрывай сессию'. Writes enriched handoff, runs LLM audit synchronously, returns result. After calling this, output the startup_text to the user in chat for copy-paste into the next session.",
+  {
+    stopped_at: z.string().describe("What the session stopped at"),
+    summary: z.string().describe("2-5 bullet points of what was accomplished"),
+    in_progress: z.string().describe("Current state: branches, PRs, uncommitted work"),
+    prs: z.array(z.object({
+      url: z.string(),
+      title: z.string(),
+      status: z.string(),
+    })).optional().describe("PRs created/merged in this session"),
+    test_results: z.string().optional().describe("Test run summary"),
+    blockers: z.string().optional().describe("Blockers for next session"),
+    next_steps: z.string().describe("Concrete next steps for next session"),
+    dirty_branches: z.string().optional().describe("Branch names with state"),
+    startup_text: z.string().describe("Ready-to-paste startup text for the next session"),
+  },
+  async (args) => {
+    const sid = getOwnedSessionIdForLogging();
+    if (!sid) {
+      return { content: [{ type: "text" as const, text: "No active AXME session found." }] };
+    }
+
+    // 1. Write enriched handoff
+    const { writeHandoff } = await import("./storage/plans.js");
+    const handoff = {
+      stoppedAt: args.stopped_at,
+      summary: args.summary,
+      inProgress: args.in_progress,
+      prs: args.prs,
+      testResults: args.test_results,
+      blockers: args.blockers ?? "None",
+      next: args.next_steps,
+      dirtyBranches: args.dirty_branches ?? "None",
+      sessionId: sid,
+      date: new Date().toISOString().slice(0, 10),
+      source: "agent" as const,
+    };
+    writeHandoff(defaultProjectPath, handoff);
+
+    // 2. Run audit synchronously (same as detached worker but inline)
+    const { runSessionCleanup } = await import("./session-cleanup.js");
+    let auditResult: string;
+    try {
+      const result = await runSessionCleanup(defaultProjectPath, sid);
+      const parts = [`Audit: ${result.auditRan ? "ran" : "skipped"}`];
+      if (result.skipped) parts.push(`(${result.skipped})`);
+      if (result.auditRan) {
+        parts.push(`memories=${result.memories}, decisions=${result.decisions}, cost=$${result.costUsd.toFixed(2)}`);
+      }
+      parts.push(`handoff saved: yes`);
+      auditResult = parts.join(", ");
+    } catch (err) {
+      auditResult = `Audit error: ${err}`;
+    }
+
+    // 3. Return result + startup text
+    const lines = [
+      `Session ${sid.slice(0, 8)} closed.`,
+      auditResult,
+      "",
+      "Handoff written. Now output the startup_text below to the user in chat:",
+      "",
+      "---",
+      args.startup_text,
+      "---",
+    ];
+    return { content: [{ type: "text" as const, text: lines.join("\n") }] };
   },
 );
 

--- a/src/session-cleanup.ts
+++ b/src/session-cleanup.ts
@@ -547,6 +547,9 @@ export async function runSessionCleanup(
       // workspace, handoff goes to workspace/.axme-code/plans/; if in a
       // single repo, it goes to that repo's .axme-code/plans/.
       if (audit.handoff) {
+        audit.handoff.sessionId = sessionId;
+        audit.handoff.date = new Date().toISOString().slice(0, 10);
+        if (!audit.handoff.source) audit.handoff.source = "auditor";
         writeHandoff(workspacePath, audit.handoff);
         result.handoffSaved = true;
       }

--- a/src/storage/plans.ts
+++ b/src/storage/plans.ts
@@ -6,7 +6,7 @@
  *   .axme-code/plans/handoff.md
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync, readdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { atomicWrite, readSafe, ensureDir, pathExists } from "./engine.js";
@@ -144,41 +144,130 @@ export function showPlan(projectPath: string, id: string): string {
 
 // --- Handoff ---
 
+const HANDOFF_RETENTION = 5; // keep last N handoff files
+
+/**
+ * Write enriched handoff. Saves as per-session file (handoff-<short-id>.md)
+ * and also overwrites handoff.md (latest, for quick access).
+ */
 export function writeHandoff(projectPath: string, handoff: SessionHandoff): void {
   ensureDir(plansRoot(projectPath));
-  const lines = [
-    "# Session Handoff", "",
-    `Stopped at: ${handoff.stoppedAt}`, "",
-    "## In Progress", handoff.inProgress, "",
-    "## Blockers", handoff.blockers, "",
-    "## Next Steps", handoff.next, "",
-    "## Dirty Branches", handoff.dirtyBranches,
-  ];
-  atomicWrite(join(plansRoot(projectPath), "handoff.md"), lines.join("\n") + "\n");
+  const content = formatHandoff(handoff);
+  // Always write latest
+  atomicWrite(join(plansRoot(projectPath), "handoff.md"), content);
+  // Per-session history file
+  if (handoff.sessionId) {
+    const shortId = handoff.sessionId.slice(0, 8);
+    atomicWrite(join(plansRoot(projectPath), `handoff-${shortId}.md`), content);
+    cleanupOldHandoffs(projectPath);
+  }
 }
 
+function formatHandoff(h: SessionHandoff): string {
+  const lines = ["# Session Handoff", ""];
+  if (h.date || h.sessionId) {
+    const meta: string[] = [];
+    if (h.date) meta.push(`Date: ${h.date}`);
+    if (h.sessionId) meta.push(`Session: ${h.sessionId.slice(0, 8)}`);
+    if (h.source) meta.push(`Source: ${h.source}`);
+    lines.push(meta.join(" | "), "");
+  }
+  lines.push(`Stopped at: ${h.stoppedAt}`, "");
+  if (h.summary) {
+    lines.push("## Summary", h.summary, "");
+  }
+  lines.push("## In Progress", h.inProgress, "");
+  if (h.prs && h.prs.length > 0) {
+    lines.push("## PRs");
+    for (const pr of h.prs) lines.push(`- [${pr.status}] ${pr.title} - ${pr.url}`);
+    lines.push("");
+  }
+  if (h.testResults) {
+    lines.push("## Test Results", h.testResults, "");
+  }
+  lines.push("## Blockers", h.blockers || "None", "");
+  lines.push("## Next Steps", h.next, "");
+  lines.push("## Dirty Branches", h.dirtyBranches || "None");
+  return lines.join("\n") + "\n";
+}
+
+function cleanupOldHandoffs(projectPath: string): void {
+  try {
+    const dir = plansRoot(projectPath);
+    const files = readdirSync(dir)
+      .filter(f => f.startsWith("handoff-") && f.endsWith(".md"))
+      .sort()
+      .reverse();
+    for (const f of files.slice(HANDOFF_RETENTION)) {
+      try { unlinkSync(join(dir, f)); } catch {}
+    }
+  } catch {}
+}
+
+/**
+ * Read the latest handoff (handoff.md).
+ * Parses both enriched and legacy minimal format.
+ */
 export function readHandoff(projectPath: string): SessionHandoff | null {
   const content = readSafe(join(plansRoot(projectPath), "handoff.md"));
-  if (!content) return null;
+  if (!content || content.trim().length < 10) return null;
   const get = (heading: string): string => {
     const regex = new RegExp(`## ${heading}\\n([\\s\\S]*?)(?=\\n## |$)`);
     const m = content.match(regex);
     return m ? m[1].trim() : "";
   };
   const stoppedMatch = content.match(/Stopped at: (.+)/);
+  const sessionMatch = content.match(/Session: (\S+)/);
+  const dateMatch = content.match(/Date: (\S+)/);
+  const sourceMatch = content.match(/Source: (\S+)/);
+  // Parse PRs if present
+  const prsSection = get("PRs");
+  const prs: Array<{ url: string; title: string; status: string }> = [];
+  if (prsSection) {
+    for (const line of prsSection.split("\n")) {
+      const m = line.match(/^- \[(\w+)\] (.+?) - (.+)$/);
+      if (m) prs.push({ status: m[1], title: m[2], url: m[3] });
+    }
+  }
   return {
     stoppedAt: stoppedMatch?.[1] ?? "",
     inProgress: get("In Progress"),
     blockers: get("Blockers"),
     next: get("Next Steps"),
     dirtyBranches: get("Dirty Branches"),
+    summary: get("Summary") || undefined,
+    testResults: get("Test Results") || undefined,
+    sessionId: sessionMatch?.[1],
+    date: dateMatch?.[1],
+    source: (sourceMatch?.[1] as "agent" | "auditor") ?? undefined,
+    prs: prs.length > 0 ? prs : undefined,
   };
 }
 
+/**
+ * Context string for axme_context - shows latest handoff to next session.
+ */
 export function handoffContext(projectPath: string): string {
   const h = readHandoff(projectPath);
   if (!h) return "";
-  return `## Previous Session Handoff\n\nStopped: ${h.stoppedAt}\nIn progress: ${h.inProgress}\nBlockers: ${h.blockers}\nNext: ${h.next}`;
+  const parts = [
+    "## Previous Session Handoff",
+    "",
+  ];
+  if (h.date || h.sessionId) {
+    parts.push(`*${[h.date, h.sessionId ? `session ${h.sessionId}` : "", h.source ? `(${h.source})` : ""].filter(Boolean).join(", ")}*`, "");
+  }
+  parts.push(`**Stopped at**: ${h.stoppedAt}`);
+  if (h.summary) parts.push("", h.summary);
+  if (h.prs && h.prs.length > 0) {
+    parts.push("", "**PRs**:");
+    for (const pr of h.prs) parts.push(`- [${pr.status}] ${pr.title} - ${pr.url}`);
+  }
+  if (h.testResults) parts.push("", `**Tests**: ${h.testResults}`);
+  parts.push("", `**In progress**: ${h.inProgress}`);
+  if (h.blockers && h.blockers !== "None") parts.push(`**Blockers**: ${h.blockers}`);
+  parts.push(`**Next steps**: ${h.next}`);
+  return parts.join("\n");
 }
 
 // --- File format ---

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -14,7 +14,7 @@ import { safetyContext, loadSafetyRules } from "../storage/safety.js";
 import { allMemoryContext, listMemories } from "../storage/memory.js";
 import { mergeDecisions, mergeMemories, mergeSafetyRules } from "../storage/workspace-merge.js";
 import { testPlanContext } from "../storage/test-plan.js";
-import { plansContext } from "../storage/plans.js";
+import { plansContext, handoffContext } from "../storage/plans.js";
 import { listPendingAudits } from "../storage/sessions.js";
 import { detectWorkspace } from "../utils/workspace-detector.js";
 import { questionsContext } from "../storage/questions.js";
@@ -127,6 +127,10 @@ export function getFullContext(projectPath: string, workspacePath?: string): str
   // Active plans
   const plans = plansContext(projectPath);
   if (plans) parts.push(plans);
+
+  // Previous session handoff - shows next session what was done and what to do next
+  const handoff = handoffContext(workspacePath ?? projectPath);
+  if (handoff) parts.push(handoff);
 
   // "parts" always has at least the Storage root header — so detect
   // "not initialized" by checking absence of any real content modules.

--- a/src/types.ts
+++ b/src/types.ts
@@ -290,6 +290,13 @@ export interface SessionHandoff {
   blockers: string;
   next: string;
   dirtyBranches: string;
+  /** Enriched fields (optional for backward compat with auditor extraction). */
+  sessionId?: string;
+  date?: string;
+  summary?: string;
+  prs?: Array<{ url: string; title: string; status: string }>;
+  testResults?: string;
+  source?: "agent" | "auditor";
 }
 
 // --- Test Plan ---


### PR DESCRIPTION
## Summary
- **Enriched handoff format**: summary, PRs list, test results, session ID, date, source (agent/auditor)
- **Per-session handoff history**: handoff-<session-id>.md files with retention (last 5)
- **handoffContext in axme_context**: next session automatically sees previous session's handoff
- **axme_close_session MCP tool**: explicit session close - agent writes detailed handoff, runs audit synchronously, outputs startup text to chat
- **Auditor prompt enriched**: extracts summary, PRs, test results from transcript (auto-close fallback)

## How it works
1. User says "close session" -> agent calls axme_close_session with detailed data
2. Tool writes enriched handoff + runs audit synchronously
3. Agent outputs startup text to user in chat (copy-paste for next session)
4. Next session's axme_context includes "Previous Session Handoff" section
5. Auto-close (process exit) also writes enriched handoff via auditor LLM extraction

## Test plan
- [x] 5/5 enriched handoff tests (write, read, parse, history, context)
- [x] 119/119 full-storage regression
- [x] Parse regression OK
- [x] 12/12 narrative worklog regression