### PR TITLE
feat: scope auto-resolve + context split for parallel loading

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,7 +87,7 @@ ${PENDING_AUDITS_GUIDANCE}${STORAGE_PATH_GUIDANCE}
 Do not defer - save when discovered.
 
 ### Available AXME Tools
-axme_context, axme_save_memory, axme_search_memory, axme_save_decision,
+axme_context, axme_oracle, axme_decisions, axme_memories, axme_save_memory, axme_save_decision,
 axme_update_safety, axme_safety, axme_status, axme_worklog, axme_workspace
 `;
 
@@ -107,7 +107,7 @@ ${PENDING_AUDITS_GUIDANCE}${STORAGE_PATH_GUIDANCE}
 - For cross-project findings: include scope parameter (e.g. scope: ["all"])
 
 ### Available AXME Tools
-axme_context, axme_save_memory, axme_search_memory, axme_save_decision,
+axme_context, axme_oracle, axme_decisions, axme_memories, axme_save_memory, axme_save_decision,
 axme_update_safety, axme_safety, axme_status, axme_worklog, axme_workspace
 `;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 import { getFullContext, getOracle, getDecisions } from "./tools/context.js";
+import { allMemoryContext } from "./storage/memory.js";
 import { saveMemoryTool, searchMemoryTool } from "./tools/memory-tools.js";
 import { saveDecisionTool } from "./tools/decision-tools.js";
 import { updateSafetyTool, showSafetyTool } from "./tools/safety-tools.js";
@@ -150,23 +151,23 @@ function buildInstructions(): string {
   ];
   if (isWorkspace) {
     parts.push(`Workspace: ${defaultWorkspacePath} (${serverWorkspace.type}, ${serverWorkspace.projects.length} projects).`);
-    parts.push("Call axme_context at session start to load workspace overview.");
+    parts.push("Call axme_context at session start to load workspace overview. It returns compact meta and instructions to call axme_oracle, axme_decisions, axme_memories in parallel.");
     parts.push("Each repo has its own .axme-code/ storage initialized during setup.");
     parts.push("Before working with any specific repo, call axme_context with that repo's path.");
   } else {
-    parts.push("Call axme_context at session start to load project knowledge base.");
+    parts.push("Call axme_context at session start. It returns compact meta and instructions to call axme_oracle, axme_decisions, axme_memories in parallel.");
   }
+  parts.push("TRUNCATED OUTPUT RULE: if ANY MCP tool output is truncated or saved to a file (you see 'Output too large' or 'saved to file'), you MUST use the Read tool to read the full file content into your context. Do not proceed with partial data.");
   parts.push("Save memories, decisions, and safety rules immediately when discovered during work.");
   parts.push("SESSION CLOSE: when the user asks to close/end the session (any language), call axme_begin_close to get the close checklist. Follow it: extract memories/decisions/safety (choosing correct scope for each), prepare handoff data, then call axme_finalize_close with everything. After finalize, output to the user: storage summary (what saved where), then startup_text.");
   parts.push("DECISION CONFLICT RULE: if two active decisions contradict each other, treat the NEWER one (by date) as authoritative. The older one is a candidate for supersede at next audit.");
   parts.push(
-    `STORAGE ROOT: ${defaultProjectPath}/.axme-code — for any direct inspection of .axme-code/ files via Bash (ls, cat, grep, find), use this ABSOLUTE path. Do NOT use relative paths from your cwd; in a multi-repo workspace your cwd may point to a child repo with its own separate .axme-code/ storage. Every session's meta.json also contains an "origin" field with its absolute parent directory — read it to verify which storage a given session belongs to.`,
+    `STORAGE ROOT: ${defaultProjectPath}/.axme-code — for any direct inspection of .axme-code/ files via Bash (ls, cat, grep, find), use this ABSOLUTE path. Do NOT use relative paths from your cwd; in a multi-repo workspace your cwd may point to a child repo with its own separate .axme-code/ storage.`,
   );
   parts.push(
-    "IMPORTANT: if axme_context output contains a '## ⚠️ Pending audits' section, " +
+    "IMPORTANT: if axme_context output contains a 'Pending audits' section, " +
       "a previous session's audit is still running and the knowledge base is incomplete. " +
-      "You MUST tell the user, offer to either wait and re-run axme_context or track with a TODO, " +
-      "and re-check axme_context periodically until the pending list is empty before relying on the knowledge base.",
+      "Tell the user, offer to wait and re-run axme_context or track with a TODO.",
   );
   return parts.join(" ");
 }
@@ -244,6 +245,36 @@ server.tool(
   async ({ project_path }) => {
 
     return { content: [{ type: "text" as const, text: getDecisions(pp(project_path)) }] };
+  },
+);
+
+// --- axme_memories ---
+server.tool(
+  "axme_memories",
+  "Show all project memories (feedback + patterns). Call at session start alongside axme_oracle and axme_decisions.",
+  {
+    project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    workspace_path: z.string().optional().describe("Absolute path to workspace root (for merged workspace + project memories)"),
+  },
+  async ({ project_path, workspace_path }) => {
+    const wsPath = wp(workspace_path);
+    const projPath = pp(project_path);
+    if (wsPath && wsPath !== projPath) {
+      const { listMemories } = await import("./storage/memory.js");
+      const { mergeMemories } = await import("./storage/workspace-merge.js");
+      const wsMemories = listMemories(wsPath);
+      const projMemories = listMemories(projPath);
+      const merged = mergeMemories(wsMemories, projMemories);
+      if (merged.length === 0) return { content: [{ type: "text" as const, text: "No memories recorded." }] };
+      const feedbacks = merged.filter(m => m.type === "feedback");
+      const patterns = merged.filter(m => m.type === "pattern");
+      const parts: string[] = ["## Project Memories"];
+      if (feedbacks.length > 0) { parts.push(`\n### Feedback (${feedbacks.length}):`); for (const m of feedbacks) parts.push(`- **${m.title}**: ${m.description}`); }
+      if (patterns.length > 0) { parts.push(`\n### Patterns (${patterns.length}):`); for (const m of patterns) parts.push(`- **${m.title}**: ${m.description}`); }
+      return { content: [{ type: "text" as const, text: parts.join("\n") }] };
+    }
+    const text = allMemoryContext(projPath);
+    return { content: [{ type: "text" as const, text: text || "No memories recorded." }] };
   },
 );
 

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -61,33 +61,16 @@ function buildStorageRootHeader(projectPath: string, workspacePath?: string): st
 export function getFullContext(projectPath: string, workspacePath?: string): string {
   const parts: string[] = [];
 
-  // Storage root header — always first so the agent sees it before anything
-  // else. Tells the agent the absolute path to use for direct file inspection.
+  // Storage root header
   parts.push(buildStorageRootHeader(projectPath, workspacePath));
 
-  // Oracle
-  const oracle = oracleContext(projectPath);
-  if (oracle) parts.push("# Project Oracle\n\n" + oracle);
-  if (workspacePath && workspacePath !== projectPath) {
-    const wsOracle = oracleContext(workspacePath);
-    if (wsOracle) parts.push("# Workspace Oracle\n\n" + wsOracle);
+  // Not initialized check
+  const storageDirExists = pathExists(join(projectPath, AXME_CODE_DIR));
+  if (!storageDirExists) {
+    return parts[0] + "\n\nProject not initialized. Ask the user to run 'axme-code setup' in terminal.";
   }
 
-  // Decisions (merged if workspace)
-  if (workspacePath && workspacePath !== projectPath) {
-    const wsDecisions = listDecisions(workspacePath);
-    const projDecisions = listDecisions(projectPath);
-    const merged = mergeDecisions(wsDecisions, projDecisions);
-    if (merged.length > 0) {
-      const lines = merged.map(d => `- **${d.id}: ${d.title}** [${d.enforce ?? "info"}] - ${d.decision}`);
-      parts.push(`## Project Decisions\n${lines.join("\n")}`);
-    }
-  } else {
-    const decisions = decisionsContext(projectPath);
-    if (decisions) parts.push(decisions);
-  }
-
-  // Safety (merged if workspace)
+  // Safety rules (small, always inline)
   if (workspacePath && workspacePath !== projectPath) {
     const wsRules = loadSafetyRules(workspacePath);
     const projRules = loadSafetyRules(projectPath);
@@ -102,60 +85,47 @@ export function getFullContext(projectPath: string, workspacePath?: string): str
     if (safety) parts.push(safety);
   }
 
-  // Memory (merged if workspace)
-  if (workspacePath && workspacePath !== projectPath) {
-    const wsMemories = listMemories(workspacePath);
-    const projMemories = listMemories(projectPath);
-    const merged = mergeMemories(wsMemories, projMemories);
-    if (merged.length > 0) {
-      const feedbacks = merged.filter(m => m.type === "feedback");
-      const patterns = merged.filter(m => m.type === "pattern");
-      const memParts: string[] = ["## Project Memories"];
-      if (feedbacks.length > 0) { memParts.push(`\n### Feedback (${feedbacks.length}):`); for (const m of feedbacks) memParts.push(`- **${m.title}**: ${m.description}`); }
-      if (patterns.length > 0) { memParts.push(`\n### Patterns (${patterns.length}):`); for (const m of patterns) memParts.push(`- **${m.title}**: ${m.description}`); }
-      parts.push(memParts.join("\n"));
-    }
-  } else {
-    const memory = allMemoryContext(projectPath);
-    if (memory) parts.push(memory);
-  }
-
-  // Test plan
-  const tests = testPlanContext(projectPath);
-  if (tests) parts.push(tests);
-
-  // Active plans
-  const plans = plansContext(projectPath);
-  if (plans) parts.push(plans);
-
-  // Previous session handoff - shows next session what was done and what to do next
+  // Previous session handoff (small, always inline)
   const handoff = handoffContext(workspacePath ?? projectPath);
   if (handoff) parts.push(handoff);
 
-  // "parts" always has at least the Storage root header — so detect
-  // "not initialized" by checking absence of any real content modules.
-  const storageDirExists = pathExists(join(projectPath, AXME_CODE_DIR));
-  if (!storageDirExists) {
-    return parts[0] + "\n\nProject not initialized. Ask the user to run 'axme-code setup' in terminal.";
+  // Last worklog entry (just 1, not 5)
+  const worklogPath = join(workspacePath ?? projectPath, AXME_CODE_DIR, "worklog.md");
+  const worklogContent = readSafe(worklogPath);
+  if (worklogContent.length > 20) {
+    const entries = worklogContent.split(/(?=^## )/m).filter(e => e.trim());
+    const last = entries.slice(-1);
+    if (last.length > 0) {
+      parts.push("# Last Session\n\n" + last[0]);
+    }
   }
 
-  // Check if LLM init was done (LLM-scanned oracle has rich content, deterministic has minimal)
+  // Test plan (small)
+  const tests = testPlanContext(projectPath);
+  if (tests) parts.push(tests);
+
+  // Active plans (small)
+  const plans = plansContext(projectPath);
+  if (plans) parts.push(plans);
+
+  // Open questions
+  try {
+    const qCtx = questionsContext(workspacePath ?? projectPath);
+    if (qCtx) parts.push(qCtx);
+  } catch {}
+
+  // LLM init warning
   const decisions = listDecisions(projectPath);
   const llmDecisions = decisions.filter(d => d.source === "init-scan");
   if (llmDecisions.length === 0 && oracleExists(projectPath)) {
     const files = loadOracleFiles(projectPath);
     const oracleIsMinimal = files && files.stack.length < 200 && !files.patterns.includes("CLAUDE.md");
     if (oracleIsMinimal) {
-      parts.push("\n---\n**WARNING:** This project was initialized with deterministic scan only (no LLM). Oracle and decisions may be incomplete. Ask the user to run `axme-code setup " + projectPath + "` in terminal for deep LLM scan.");
+      parts.push("**WARNING:** This project was initialized with deterministic scan only (no LLM). Run `axme-code setup " + projectPath + "` for deep LLM scan.");
     }
   }
 
-  // Pending audits warning: check BOTH the current project AND the workspace
-  // root (if different), so the agent sees audits running at either level.
-  // listPendingAudits derives state from SessionMeta.auditStatus and already
-  // filters out stale "pending" entries older than AUDIT_STALE_TIMEOUT_MS
-  // (crashed auditors), so the returned list represents genuinely in-flight
-  // audits only.
+  // Pending audits warning
   const pendingProject = listPendingAudits(projectPath);
   const pendingWorkspace = workspacePath && workspacePath !== projectPath
     ? listPendingAudits(workspacePath)
@@ -168,40 +138,28 @@ export function getFullContext(projectPath: string, workspacePath?: string): str
     const lines = [
       "## ⚠️ Pending audits (knowledge base may be incomplete)",
       "",
-      `${allPending.length} previous session audit(s) are still running. Their extracted memories, decisions, and handoff notes are NOT yet reflected in the knowledge base above.`,
-      "",
-      "Pending:",
+      `${allPending.length} previous session audit(s) are still running.`,
       ...allPending.map(p => {
         const startedAgo = Math.round((Date.now() - new Date(p.startedAt).getTime()) / 1000);
         return `- session ${p.sessionId.slice(0, 8)} at ${p.location} level, started ${startedAgo}s ago, phase=${p.phase}`;
       }),
       "",
-      "**Agent action required**: tell the user about the pending audit(s) and offer two options:",
-      "  1. Wait a few minutes and re-run `axme_context` to pick up the fresh knowledge before proceeding.",
-      "  2. Add a TODO to check back in N minutes and continue in parallel until then, re-checking `axme_context` periodically until the pending list is empty.",
-      "Keep the TODO open until all pending audits are gone.",
+      "**Action**: tell the user, then either wait and re-run `axme_context`, or add a TODO to re-check periodically.",
     ];
     parts.push(lines.join("\n"));
   }
 
-  // Open questions: show any pending questions from previous sessions/audits
-  try {
-    const qCtx = questionsContext(workspacePath ?? projectPath);
-    if (qCtx) parts.push(qCtx);
-  } catch {}
-
-  // Recent worklog: show last few narrative session summaries so the agent
-  // knows what happened in recent sessions without reading the full history.
-  const worklogPath = join(workspacePath ?? projectPath, AXME_CODE_DIR, "worklog.md");
-  const worklogContent = readSafe(worklogPath);
-  if (worklogContent.length > 20) {
-    // Extract last 5 entries (each starts with "## ")
-    const entries = worklogContent.split(/(?=^## )/m).filter(e => e.trim());
-    const recent = entries.slice(-5);
-    if (recent.length > 0) {
-      parts.push("# Recent Session History\n\n" + recent.join("\n"));
-    }
-  }
+  // Parallel loading instructions
+  parts.push([
+    "## Load Full Knowledge Base",
+    "",
+    "Call these three tools **in parallel** now to load the complete knowledge base:",
+    "1. `axme_oracle` - project stack, structure, patterns, glossary",
+    "2. `axme_decisions` - architectural decisions with enforce levels",
+    "3. `axme_memories` - feedback and validated patterns",
+    "",
+    "**IMPORTANT**: if any tool output is truncated or saved to a file, use the Read tool to read the full file content into your context. Do not proceed with partial data.",
+  ].join("\n"));
 
   return parts.join("\n\n");
 }


### PR DESCRIPTION
## Summary
- **Scope auto-resolve**: when `scope: ["repo-name"]` is passed without `project_path`, server resolves to `workspace/repo-name` automatically. Applies to `axme_save_memory`, `axme_save_decision`, `axme_finalize_close`.
- **Context split**: `axme_context` now returns compact meta (~5-10K) + instructions to call `axme_oracle`, `axme_decisions`, `axme_memories` in parallel. Each sub-call fits within tool output limits.
- **New tool**: `axme_memories` - returns all memories (workspace-aware merge)
- **Truncated output fallback**: MCP instructions tell agent to Read full file if any output is truncated
- Worklog reduced from 5 entries to 1 in context

## Test plan
- [x] scope auto-resolve: tested with `scope: ["axme-code"]`, `scope: ["all"]`, no scope
- [ ] Reload VS Code, call `axme_context` - verify compact output with parallel load instructions
- [ ] Call `axme_oracle`, `axme_decisions`, `axme_memories` in parallel - verify each returns data