### PR TITLE
fix: git -C strip + skip merged check on checkout chains

### DIFF
--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -152,7 +152,10 @@ function handlePreToolUse(sessionOrigin: string, event: HookInput): void {
       // Track effective cwd through cd/pushd segments, then check each git
       // segment with the correct cwd. If cwd cannot be determined (variables,
       // subshells), block with instruction to use git -C.
+      // If chain contains git checkout (branch switch), skip merged-PR check
+      // because the hook runs BEFORE execution - current branch will change.
       const segments = splitCommandSegments(command);
+      const hasCheckout = segments.some(s => /^\s*git\s+(checkout|switch)\b/.test(s.trim()));
       let effectiveCwd = process.cwd();
       let cwdResolved = true;
       for (const seg of segments) {
@@ -182,7 +185,8 @@ function handlePreToolUse(sessionOrigin: string, event: HookInput): void {
             verdict = { allowed: false, reason: `Cannot determine target directory for git command. Use explicit path: git -C /absolute/path ${trimmed.replace(/^git\s+/, '')}` };
             break;
           }
-          verdict = checkGit(rules, trimmed, gitCwd);
+          // Skip merged-PR check if chain includes checkout (branch will change)
+          verdict = checkGit(rules, trimmed, gitCwd, hasCheckout);
           if (!verdict.allowed) break;
         }
       }

--- a/src/storage/safety.ts
+++ b/src/storage/safety.ts
@@ -381,8 +381,9 @@ function checkMergedBranch(command: string, cwd?: string): SafetyVerdict | null 
  * and the `+refspec` form (`git push origin +main`) are all recognized;
  * `-fixes` and similar substrings are not.
  */
-export function checkGit(rules: SafetyRules, command: string, cwd?: string): SafetyVerdict {
-  const stripped = stripQuoted(command.trim());
+export function checkGit(rules: SafetyRules, command: string, cwd?: string, skipMergedCheck?: boolean): SafetyVerdict {
+  // Strip "git -C <path>" so startsWith checks work: "git -C foo commit" -> "git commit"
+  const stripped = stripQuoted(command.trim()).replace(/^(git\s+)(?:-C\s+\S+\s+)+/, "$1");
   if (!rules.git.allowForcePush && stripped.startsWith("git push")) {
     // Split the push command into argv-ish tokens and inspect them as whole
     // words rather than scanning for substrings. This avoids the bug where
@@ -423,7 +424,8 @@ export function checkGit(rules: SafetyRules, command: string, cwd?: string): Saf
     }
   }
   // Block commit/push to a branch that already has a merged PR.
-  if (stripped.startsWith("git push") || stripped.startsWith("git commit") || stripped.startsWith("git add")) {
+  // Skip if the command chain includes git checkout (branch will change before commit).
+  if (!skipMergedCheck && (stripped.startsWith("git push") || stripped.startsWith("git commit") || stripped.startsWith("git add"))) {
     const verdict = checkMergedBranch(stripped, cwd);
     if (verdict && !verdict.allowed) return verdict;
   }


### PR DESCRIPTION
## Summary
1. Strip `git -C <path>` prefix in checkGit before startsWith checks. `git -C repo commit` now correctly matches `git commit` pattern.
2. Skip merged-PR check when command chain includes `git checkout`/`git switch`. Hook runs BEFORE execution, so current branch is stale when checkout is in the chain.

## Root cause
- `git -C axme-code commit` was not blocked because `startsWith("git commit")` failed
- `git stash && git checkout main && git commit` was blocked because hook checked current (pre-checkout) branch