### PR TITLE
feat: paginate MCP tool outputs to prevent truncation

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,8 +12,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
-import { getFullContext, getOracle, getDecisions } from "./tools/context.js";
-import { allMemoryContext } from "./storage/memory.js";
+import { getFullContextSections, getOracle, getDecisions } from "./tools/context.js";
+import { allMemoryContext, getMemorySections } from "./storage/memory.js";
+import { getOracleSections } from "./storage/oracle.js";
+import { getDecisionSections } from "./storage/decisions.js";
+import { paginateSections } from "./utils/pagination.js";
 import { saveMemoryTool } from "./tools/memory-tools.js";
 import { saveDecisionTool } from "./tools/decision-tools.js";
 import { updateSafetyTool, showSafetyTool } from "./tools/safety-tools.js";
@@ -221,10 +224,12 @@ server.tool(
   {
     project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
     workspace_path: z.string().optional().describe("Absolute path to workspace root (defaults to detected workspace)"),
+    page: z.number().optional().describe("Page number (1-based). Omit for first page. Follow pagination instructions if output is split."),
   },
-  async ({ project_path, workspace_path }) => {
-
-    return { content: [{ type: "text" as const, text: getFullContext(pp(project_path), wp(workspace_path)) }] };
+  async ({ project_path, workspace_path, page }) => {
+    const sections = getFullContextSections(pp(project_path), wp(workspace_path));
+    const result = paginateSections(sections, page ?? 1, "axme_context", { project_path, workspace_path });
+    return { content: [{ type: "text" as const, text: result.text }] };
   },
 );
 
@@ -234,17 +239,19 @@ server.tool(
   "Show project oracle data (stack, structure, patterns, glossary).",
   {
     project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    page: z.number().optional().describe("Page number (1-based). Omit for first page. Follow pagination instructions if output is split."),
   },
-  async ({ project_path }) => {
+  async ({ project_path, page }) => {
     const resolved = pp(project_path);
     deliveredContext.add("oracle:" + resolved);
+    let sections = getOracleSections(resolved);
     // If requesting repo oracle and workspace oracle was already delivered, return repo-only
     if (isWorkspace && defaultWorkspacePath && resolved !== defaultWorkspacePath
         && deliveredContext.has("oracle:" + defaultWorkspacePath)) {
-      return { content: [{ type: "text" as const, text: getOracle(resolved) + "\n\n*(Workspace oracle already loaded)*" }] };
+      sections = [...sections, "*(Workspace oracle already loaded)*"];
     }
-    // If workspace call and repo exists, return workspace only (repo loaded separately)
-    return { content: [{ type: "text" as const, text: getOracle(resolved) }] };
+    const result = paginateSections(sections, page ?? 1, "axme_oracle", { project_path });
+    return { content: [{ type: "text" as const, text: result.text }] };
   },
 );
 
@@ -254,16 +261,19 @@ server.tool(
   "Show all project decisions with enforce levels.",
   {
     project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    page: z.number().optional().describe("Page number (1-based). Omit for first page. Follow pagination instructions if output is split."),
   },
-  async ({ project_path }) => {
+  async ({ project_path, page }) => {
     const resolved = pp(project_path);
     deliveredContext.add("decisions:" + resolved);
+    let sections = getDecisionSections(resolved);
     // If requesting repo decisions and workspace decisions already delivered, return repo-only
     if (isWorkspace && defaultWorkspacePath && resolved !== defaultWorkspacePath
         && deliveredContext.has("decisions:" + defaultWorkspacePath)) {
-      return { content: [{ type: "text" as const, text: getDecisions(resolved) + "\n\n*(Workspace decisions already loaded)*" }] };
+      sections = [...sections, "*(Workspace decisions already loaded)*"];
     }
-    return { content: [{ type: "text" as const, text: getDecisions(resolved) }] };
+    const result = paginateSections(sections, page ?? 1, "axme_decisions", { project_path });
+    return { content: [{ type: "text" as const, text: result.text }] };
   },
 );
 
@@ -273,37 +283,54 @@ server.tool(
   "Show all project memories (feedback + patterns). Call at session start alongside axme_oracle and axme_decisions.",
   {
     project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    page: z.number().optional().describe("Page number (1-based). Omit for first page. Follow pagination instructions if output is split."),
   },
-  async ({ project_path }) => {
+  async ({ project_path, page }) => {
     const resolved = pp(project_path);
     deliveredContext.add("memories:" + resolved);
+
+    let sections: string[];
 
     // If requesting repo memories and workspace memories already delivered: repo-only
     if (isWorkspace && defaultWorkspacePath && resolved !== defaultWorkspacePath
         && deliveredContext.has("memories:" + defaultWorkspacePath)) {
-      const text = allMemoryContext(resolved);
-      return { content: [{ type: "text" as const, text: (text || "No repo-specific memories.") + "\n\n*(Workspace memories already loaded)*" }] };
+      sections = getMemorySections(resolved);
+      if (sections.length === 0) sections = ["No repo-specific memories."];
+      sections.push("*(Workspace memories already loaded)*");
     }
-
     // If requesting repo memories but workspace NOT yet delivered: merged (workspace + repo)
-    if (isWorkspace && defaultWorkspacePath && resolved !== defaultWorkspacePath) {
+    else if (isWorkspace && defaultWorkspacePath && resolved !== defaultWorkspacePath) {
       const { listMemories } = await import("./storage/memory.js");
       const { mergeMemories } = await import("./storage/workspace-merge.js");
       const wsMemories = listMemories(defaultWorkspacePath);
       const projMemories = listMemories(resolved);
       const merged = mergeMemories(wsMemories, projMemories);
-      if (merged.length === 0) return { content: [{ type: "text" as const, text: "No memories recorded." }] };
+      if (merged.length === 0) {
+        return { content: [{ type: "text" as const, text: "No memories recorded." }] };
+      }
       const feedbacks = merged.filter(m => m.type === "feedback");
       const patterns = merged.filter(m => m.type === "pattern");
-      const parts: string[] = ["## Project Memories (workspace + repo merged)"];
-      if (feedbacks.length > 0) { parts.push(`\n### Feedback (${feedbacks.length}):`); for (const m of feedbacks) parts.push(`- **${m.title}**: ${m.description}`); }
-      if (patterns.length > 0) { parts.push(`\n### Patterns (${patterns.length}):`); for (const m of patterns) parts.push(`- **${m.title}**: ${m.description}`); }
-      return { content: [{ type: "text" as const, text: parts.join("\n") }] };
+      sections = ["## Project Memories (workspace + repo merged)"];
+      if (feedbacks.length > 0) {
+        sections.push(`### Feedback (${feedbacks.length}):\n` +
+          feedbacks.map(m => `- **${m.title}**: ${m.description}`).join("\n"));
+      }
+      if (patterns.length > 0) {
+        sections.push(`### Patterns (${patterns.length}):\n` +
+          patterns.map(m => `- **${m.title}**: ${m.description}`).join("\n"));
+      }
+    }
+    // Workspace call or single-repo: return as-is
+    else {
+      sections = getMemorySections(resolved);
+      if (sections.length === 0) {
+        return { content: [{ type: "text" as const, text: "No memories recorded." }] };
+      }
+      sections = ["## Project Memories", ...sections];
     }
 
-    // Workspace call or single-repo: return as-is
-    const text = allMemoryContext(resolved);
-    return { content: [{ type: "text" as const, text: text || "No memories recorded." }] };
+    const result = paginateSections(sections, page ?? 1, "axme_memories", { project_path });
+    return { content: [{ type: "text" as const, text: result.text }] };
   },
 );
 

--- a/src/storage/decisions.ts
+++ b/src/storage/decisions.ts
@@ -273,12 +273,17 @@ export function listScopedDecisions(projectPath: string, workspacePath?: string)
 }
 
 export function showDecisions(projectPath: string): string {
+  return getDecisionSections(projectPath).join("\n");
+}
+
+/** Return decisions as array of line sections (for pagination). */
+export function getDecisionSections(projectPath: string): string[] {
   const decisions = listDecisions(projectPath);
-  if (decisions.length === 0) return "No decisions recorded.";
+  if (decisions.length === 0) return ["No decisions recorded."];
   return decisions.map(d => {
     const badge = d.enforce ? ` [${d.enforce}]` : "";
     return `- **${d.id}: ${d.title}**${badge} - ${d.decision}`;
-  }).join("\n");
+  });
 }
 
 export function toSlug(text: string): string {

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -182,22 +182,27 @@ export function memoryContext(projectPath: string, keywords: string[]): string {
 }
 
 export function allMemoryContext(projectPath: string): string {
+  return getMemorySections(projectPath).join("\n");
+}
+
+/** Return memories as array of sections (for pagination). */
+export function getMemorySections(projectPath: string): string[] {
   const all = listMemories(projectPath);
-  if (all.length === 0) return "";
+  if (all.length === 0) return [];
 
   const feedbacks = all.filter(m => m.type === "feedback");
   const patterns = all.filter(m => m.type === "pattern");
-  const parts: string[] = ["## Project Memories"];
+  const sections: string[] = [];
 
   if (feedbacks.length > 0) {
-    parts.push(`\n### Feedback (${feedbacks.length}):`);
-    for (const m of feedbacks) parts.push(`- **${m.title}**: ${m.description}`);
+    sections.push(`### Feedback (${feedbacks.length}):\n` +
+      feedbacks.map(m => `- **${m.title}**: ${m.description}`).join("\n"));
   }
   if (patterns.length > 0) {
-    parts.push(`\n### Patterns (${patterns.length}):`);
-    for (const m of patterns) parts.push(`- **${m.title}**: ${m.description}`);
+    sections.push(`### Patterns (${patterns.length}):\n` +
+      patterns.map(m => `- **${m.title}**: ${m.description}`).join("\n"));
   }
-  return parts.join("\n");
+  return sections;
 }
 
 export function showMemories(projectPath: string, type?: MemoryType): string {

--- a/src/storage/oracle.ts
+++ b/src/storage/oracle.ts
@@ -62,15 +62,20 @@ export function oracleContext(projectPath: string): string {
  * Format oracle for display.
  */
 export function showOracle(projectPath: string): string {
+  return getOracleSections(projectPath).join("\n\n---\n\n");
+}
+
+/** Return oracle as array of sections (for pagination). */
+export function getOracleSections(projectPath: string): string[] {
   const files = loadOracleFiles(projectPath);
-  if (!files) return "Oracle not initialized. Run axme_init first.";
+  if (!files) return ["Oracle not initialized. Run axme_init first."];
 
   const sections: string[] = [];
   if (files.stack) sections.push("# Stack\n\n" + files.stack);
   if (files.structure) sections.push("# Structure\n\n" + files.structure);
   if (files.patterns) sections.push("# Patterns\n\n" + files.patterns);
   if (files.glossary) sections.push("# Glossary\n\n" + files.glossary);
-  return sections.join("\n\n---\n\n");
+  return sections;
 }
 
 export function oracleExists(projectPath: string): boolean {

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -55,10 +55,10 @@ function buildStorageRootHeader(projectPath: string, workspacePath?: string): st
 }
 
 /**
- * Get full project context (oracle + decisions + safety + memory + test plan + plans).
+ * Get full project context as array of logical sections (for pagination).
  * When workspacePath provided, merges workspace + project data.
  */
-export function getFullContext(projectPath: string, workspacePath?: string): string {
+export function getFullContextSections(projectPath: string, workspacePath?: string): string[] {
   const parts: string[] = [];
 
   // Storage root header
@@ -67,7 +67,7 @@ export function getFullContext(projectPath: string, workspacePath?: string): str
   // Not initialized check
   const storageDirExists = pathExists(join(projectPath, AXME_CODE_DIR));
   if (!storageDirExists) {
-    return parts[0] + "\n\nProject not initialized. Ask the user to run 'axme-code setup' in terminal.";
+    return [parts[0] + "\n\nProject not initialized. Ask the user to run 'axme-code setup' in terminal."];
   }
 
   // Safety rules (small, always inline)
@@ -161,7 +161,12 @@ export function getFullContext(projectPath: string, workspacePath?: string): str
     "**IMPORTANT**: if any tool output is truncated or saved to a file, use the Read tool to read the full file content into your context. Do not proceed with partial data.",
   ].join("\n"));
 
-  return parts.join("\n\n");
+  return parts;
+}
+
+/** Legacy joined output (for backward compat where needed). */
+export function getFullContext(projectPath: string, workspacePath?: string): string {
+  return getFullContextSections(projectPath, workspacePath).join("\n\n");
 }
 
 export function getOracle(projectPath: string): string {

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,77 @@
+/**
+ * Pagination utility for MCP tool outputs.
+ *
+ * Splits content into pages by logical sections to prevent
+ * MCP output truncation. Each page includes navigation instructions
+ * telling the agent to call the tool again with the next page number.
+ */
+
+/** Default character limit per page (well under MCP truncation threshold). */
+export const DEFAULT_PAGE_CHAR_LIMIT = 25_000;
+
+export interface PaginatedOutput {
+  text: string;
+  page: number;
+  totalPages: number;
+}
+
+/**
+ * Paginate an array of text sections.
+ *
+ * Keeps sections intact (never splits mid-section).
+ * Returns the requested page with navigation footer.
+ *
+ * @param sections - Logical content blocks (each becomes an atomic unit)
+ * @param page - Requested page number (1-based, clamped to valid range)
+ * @param toolName - MCP tool name for the "call next" instruction
+ * @param toolArgs - Current tool arguments (page will be overridden)
+ * @param charLimit - Max characters per page
+ */
+export function paginateSections(
+  sections: string[],
+  page: number,
+  toolName: string,
+  toolArgs: Record<string, unknown>,
+  charLimit: number = DEFAULT_PAGE_CHAR_LIMIT,
+): PaginatedOutput {
+  // Fast path: everything fits in one page
+  const total = sections.reduce((sum, s) => sum + s.length, 0);
+  if (total <= charLimit) {
+    return { text: sections.join("\n\n"), page: 1, totalPages: 1 };
+  }
+
+  // Build pages by packing sections until limit
+  const pages: string[][] = [[]];
+  let currentSize = 0;
+  let idx = 0;
+
+  for (const section of sections) {
+    // Start new page if adding this section exceeds limit AND page isn't empty
+    if (currentSize + section.length > charLimit && pages[idx].length > 0) {
+      idx++;
+      pages.push([]);
+      currentSize = 0;
+    }
+    pages[idx].push(section);
+    currentSize += section.length;
+  }
+
+  const totalPages = pages.length;
+  const safePage = Math.max(1, Math.min(page, totalPages));
+  const content = pages[safePage - 1].join("\n\n");
+
+  // Navigation footer
+  let footer = "";
+  if (safePage < totalPages) {
+    const nextArgs = { ...toolArgs, page: safePage + 1 };
+    const argsStr = Object.entries(nextArgs)
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+      .join(", ");
+    footer = `\n\n---\n**Page ${safePage}/${totalPages}** - call \`${toolName}\` with \`{ ${argsStr} }\` to load next page.`;
+  } else if (totalPages > 1) {
+    footer = `\n\n---\n**Page ${safePage}/${totalPages}** - all content loaded.`;
+  }
+
+  return { text: content + footer, page: safePage, totalPages };
+}

--- a/test/pagination-integration.test.ts
+++ b/test/pagination-integration.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { paginateSections } from "../src/utils/pagination.js";
+import { getOracleSections } from "../src/storage/oracle.js";
+import { getDecisionSections } from "../src/storage/decisions.js";
+import { getMemorySections } from "../src/storage/memory.js";
+import { getFullContextSections } from "../src/tools/context.js";
+
+const WORKSPACE = "/home/georgeb/axme-workspace";
+const AXME_CODE = "/home/georgeb/axme-workspace/axme-code";
+const CONTROL_PLANE = "/home/georgeb/axme-workspace/axme-control-plane";
+
+describe("pagination integration with real data", () => {
+  it("workspace oracle paginates correctly", () => {
+    const sections = getOracleSections(WORKSPACE);
+    assert.ok(sections.length > 0, "should have oracle sections");
+    const totalChars = sections.reduce((s, sec) => s + sec.length, 0);
+    console.log(`  workspace oracle: ${sections.length} sections, ${totalChars} chars`);
+
+    const p1 = paginateSections(sections, 1, "axme_oracle", {});
+    console.log(`  page 1/${p1.totalPages}: ${p1.text.length} chars`);
+    if (p1.totalPages > 1) {
+      assert.ok(p1.text.includes("page: 2"), "should have next-page instruction");
+      const p2 = paginateSections(sections, 2, "axme_oracle", {});
+      console.log(`  page 2/${p2.totalPages}: ${p2.text.length} chars`);
+    }
+  });
+
+  it("axme-code decisions paginates correctly (largest: 114KB)", () => {
+    const sections = getDecisionSections(AXME_CODE);
+    assert.ok(sections.length > 0, "should have decisions");
+    const totalChars = sections.reduce((s, sec) => s + sec.length, 0);
+    console.log(`  axme-code decisions: ${sections.length} items, ${totalChars} chars`);
+
+    // Walk all pages
+    let page = 1;
+    let allContent = "";
+    while (true) {
+      const result = paginateSections(sections, page, "axme_decisions", { project_path: AXME_CODE });
+      console.log(`  page ${result.page}/${result.totalPages}: ${result.text.length} chars`);
+      assert.ok(result.text.length <= 30_000, `page ${page} too large: ${result.text.length}`);
+      allContent += result.text;
+      if (result.page >= result.totalPages) break;
+      page++;
+    }
+    // All decisions should be present across pages
+    for (const sec of sections) {
+      const snippet = sec.slice(0, 50);
+      assert.ok(allContent.includes(snippet), `missing: ${snippet}`);
+    }
+  });
+
+  it("workspace context paginates correctly", () => {
+    const sections = getFullContextSections(WORKSPACE);
+    const totalChars = sections.reduce((s, sec) => s + sec.length, 0);
+    console.log(`  workspace context: ${sections.length} sections, ${totalChars} chars`);
+
+    const p1 = paginateSections(sections, 1, "axme_context", { workspace_path: WORKSPACE });
+    console.log(`  page 1/${p1.totalPages}: ${p1.text.length} chars`);
+    // First page should always have storage root header
+    assert.ok(p1.text.includes("AXME Storage Root"), "first page must include storage root");
+    // First page should always have safety rules
+    assert.ok(p1.text.includes("Safety Rules") || p1.text.includes("Safety"), "first page should include safety");
+  });
+
+  it("control-plane oracle paginates correctly", () => {
+    const sections = getOracleSections(CONTROL_PLANE);
+    const totalChars = sections.reduce((s, sec) => s + sec.length, 0);
+    console.log(`  control-plane oracle: ${sections.length} sections, ${totalChars} chars`);
+
+    const p1 = paginateSections(sections, 1, "axme_oracle", { project_path: CONTROL_PLANE });
+    console.log(`  page 1/${p1.totalPages}: ${p1.text.length} chars`);
+    assert.ok(p1.text.length <= 30_000, `page 1 too large: ${p1.text.length}`);
+  });
+
+  it("no data loss across pages", () => {
+    const sections = getDecisionSections(WORKSPACE);
+    const totalChars = sections.reduce((s, sec) => s + sec.length, 0);
+    console.log(`  workspace decisions: ${sections.length} items, ${totalChars} chars`);
+
+    // Collect all pages
+    let page = 1;
+    const pageTexts: string[] = [];
+    while (true) {
+      const result = paginateSections(sections, page, "axme_decisions", {});
+      pageTexts.push(result.text);
+      if (result.page >= result.totalPages) break;
+      page++;
+    }
+    console.log(`  ${pageTexts.length} total pages`);
+
+    // Every section should appear in exactly one page
+    for (const sec of sections) {
+      const found = pageTexts.filter(pt => pt.includes(sec));
+      assert.equal(found.length, 1, `section should appear in exactly 1 page: ${sec.slice(0, 60)}`);
+    }
+  });
+});

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { paginateSections, DEFAULT_PAGE_CHAR_LIMIT } from "../src/utils/pagination.js";
+
+describe("paginateSections", () => {
+  it("returns all content in one page when under limit", () => {
+    const sections = ["Section A", "Section B", "Section C"];
+    const result = paginateSections(sections, 1, "test_tool", {});
+    assert.equal(result.page, 1);
+    assert.equal(result.totalPages, 1);
+    assert.ok(result.text.includes("Section A"));
+    assert.ok(result.text.includes("Section C"));
+    assert.ok(!result.text.includes("Page"));
+  });
+
+  it("splits content into pages when over limit", () => {
+    const bigSection = "x".repeat(15_000);
+    const sections = [
+      "# Header\n" + bigSection,
+      "# Middle\n" + bigSection,
+      "# Footer\n" + bigSection,
+    ];
+    const p1 = paginateSections(sections, 1, "my_tool", { project_path: "/test" }, 20_000);
+    assert.equal(p1.page, 1);
+    assert.ok(p1.totalPages > 1, `expected >1 pages, got ${p1.totalPages}`);
+    assert.ok(p1.text.includes("# Header"));
+    assert.ok(p1.text.includes("call `my_tool`"));
+    assert.ok(p1.text.includes("page: 2"));
+
+    const p2 = paginateSections(sections, 2, "my_tool", { project_path: "/test" }, 20_000);
+    assert.equal(p2.page, 2);
+    assert.ok(p2.text.includes("# Middle") || p2.text.includes("# Footer"));
+  });
+
+  it("clamps page number to valid range", () => {
+    const sections = ["A", "B"];
+    const result = paginateSections(sections, 99, "t", {});
+    assert.equal(result.page, 1); // everything fits in 1 page
+    assert.equal(result.totalPages, 1);
+  });
+
+  it("clamps page 0 to 1", () => {
+    const sections = ["A"];
+    const result = paginateSections(sections, 0, "t", {});
+    assert.equal(result.page, 1);
+  });
+
+  it("last page shows 'all content loaded'", () => {
+    const bigSection = "x".repeat(15_000);
+    const sections = [bigSection, bigSection];
+    const p1 = paginateSections(sections, 1, "t", {}, 16_000);
+    assert.ok(p1.totalPages === 2);
+    const p2 = paginateSections(sections, 2, "t", {}, 16_000);
+    assert.ok(p2.text.includes("all content loaded"));
+  });
+
+  it("preserves tool args in pagination instruction", () => {
+    const bigSection = "x".repeat(15_000);
+    const sections = [bigSection, bigSection, bigSection];
+    const result = paginateSections(sections, 1, "axme_oracle", { project_path: "/my/repo" }, 16_000);
+    assert.ok(result.text.includes("axme_oracle"));
+    assert.ok(result.text.includes("/my/repo"));
+  });
+
+  it("single oversized section still gets returned", () => {
+    const huge = "x".repeat(50_000);
+    const result = paginateSections([huge], 1, "t", {}, 20_000);
+    assert.equal(result.totalPages, 1);
+    assert.equal(result.page, 1);
+    assert.ok(result.text.length >= 50_000);
+  });
+
+  it("uses DEFAULT_PAGE_CHAR_LIMIT when no limit specified", () => {
+    assert.equal(DEFAULT_PAGE_CHAR_LIMIT, 25_000);
+    const small = "test";
+    const result = paginateSections([small], 1, "t", {});
+    assert.equal(result.totalPages, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `page` parameter to `axme_context`, `axme_oracle`, `axme_decisions`, `axme_memories`
- Server checks total output size against 25K char limit and splits by logical sections
- Each page includes navigation instructions for the agent to call the next page
- New `paginateSections()` utility in `src/utils/pagination.ts`
- Section-returning functions added to oracle/decisions/memory storage modules

## Tested on real workspace data
| Tool | Source | Total chars | Pages |
|---|---|---|---|
| oracle | workspace | 34K | 2 |
| oracle | control-plane | 26K | 2 |
| decisions | axme-code | 50K | 3 |
| decisions | workspace | 27K | 2 |
| context | workspace | 7K | 1 (no split needed) |

## Test plan
- [x] 8 unit tests for pagination utility (edge cases, clamping, data preservation)
- [x] 5 integration tests with real .axme-code data (no data loss, correct page sizes)
- [x] Build + type check green
- [ ] E2E: restart MCP server, call axme_oracle on workspace, verify page 1 returns with next-page instruction