### PR TITLE
feat: #!axme gate protocol for git commit/push

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -168,6 +168,7 @@ function buildInstructions(): string {
   }
   parts.push("TRUNCATED OUTPUT RULE: if ANY MCP tool output is truncated or saved to a file (you see 'Output too large' or 'saved to file'), you MUST use the Read tool to read the full file content into your context. Do not proceed with partial data.");
   parts.push("Save memories, decisions, and safety rules immediately when discovered during work.");
+  parts.push("GIT COMMIT/PUSH GATE: every git commit and git push command MUST end with `#!axme pr=<NUMBER|none> repo=<OWNER/REPO>`. Example: `git commit -m \"fix bug\" #!axme pr=42 repo=AxmeAI/axme-code`. Use pr=none if no PR exists yet. Without this suffix the command will be blocked.");
   parts.push("SESSION CLOSE: when the user asks to close/end the session (any language), call axme_begin_close to get the close checklist. Follow it: extract memories/decisions/safety (choosing correct scope for each), prepare handoff data, then call axme_finalize_close with everything. After finalize, output to the user: storage summary (what saved where), then startup_text.");
   parts.push("DECISION CONFLICT RULE: if two active decisions contradict each other, treat the NEWER one (by date) as authoritative. The older one is a candidate for supersede at next audit.");
   parts.push(

--- a/src/storage/safety.ts
+++ b/src/storage/safety.ts
@@ -320,56 +320,75 @@ export function checkBash(rules: SafetyRules, command: string): SafetyVerdict {
  * For `git push`, also parses branch from command tokens.
  */
 /**
- * Detect the current git branch in the given directory.
- * For push commands, also parses branch from "git push origin <branch>".
+ * Parse #!axme gate metadata from a command string.
+ *
+ * Format: `git commit -m "msg" #!axme pr=37 repo=AxmeAI/axme-code`
+ * The `#!axme` marker is a bash comment (shell ignores it), but the hook
+ * sees the full command before execution and parses the metadata.
+ *
+ * Returns null if no #!axme marker found.
  */
-function detectBranch(command: string, cwd?: string): string | null {
-  // For push commands, try parsing branch from tokens
-  if (command.startsWith("git push")) {
-    const tokens = command.split(/\s+/);
-    for (let i = 2; i < tokens.length; i++) {
-      if (tokens[i] === "origin" || tokens[i] === "upstream") {
-        const candidate = tokens[i + 1];
-        if (candidate && !candidate.startsWith("-") && !candidate.startsWith("+")) {
-          return candidate;
-        }
-      }
-    }
-  }
+export function parseAxmeGate(command: string): { pr: string; repo: string } | null {
+  const match = command.match(/#!axme\s+(.*)/);
+  if (!match) return null;
+  const pairs = match[1].trim();
+  const prMatch = pairs.match(/\bpr=(\S+)/);
+  const repoMatch = pairs.match(/\brepo=(\S+)/);
+  if (!prMatch || !repoMatch) return null;
+  return { pr: prMatch[1], repo: repoMatch[1] };
+}
 
-  // Run git branch --show-current in the resolved cwd
-  try {
-    return execSync("git branch --show-current", {
-      encoding: "utf-8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"],
-      ...(cwd ? { cwd } : {}),
-    }).trim() || null;
-  } catch {
-    return null;
-  }
+const AXME_GATE_INSTRUCTION =
+  'BLOCKED: git commit/push requires #!axme safety metadata. ' +
+  'Retry with: `<your command> #!axme pr=<PR_NUMBER|none> repo=<OWNER/REPO>` ' +
+  '(pr=none if no PR created yet).';
+
+/**
+ * Check if a PR is merged via gh CLI. Returns true if merged, false otherwise.
+ * Throws on network/CLI errors (caller decides fail-open vs fail-closed).
+ */
+function isPrMerged(prNumber: string, repo: string): boolean {
+  const result = execSync(
+    `gh pr view ${prNumber} --repo "${repo}" --json state --jq .state`,
+    { encoding: "utf-8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"] },
+  ).trim();
+  return result === "MERGED";
 }
 
 /**
- * Check if the current branch has a merged PR. Used by checkGit to block
- * commit/add/push on stale branches.
+ * Verify #!axme gate on git commit/push commands.
+ * - No gate marker -> BLOCK with format instruction
+ * - pr=none -> ALLOW (new branch, no PR yet)
+ * - pr=<number> -> check if merged, block if so
+ * - gh check fails -> BLOCK (fail-closed)
  */
-function checkMergedBranch(command: string, cwd?: string): SafetyVerdict | null {
+function checkAxmeGate(fullCommand: string): SafetyVerdict | null {
+  const gate = parseAxmeGate(fullCommand);
+  if (!gate) {
+    return { allowed: false, reason: AXME_GATE_INSTRUCTION };
+  }
+  if (gate.pr === "none") {
+    return null; // no PR yet, allowed
+  }
+  const prNum = parseInt(gate.pr, 10);
+  if (isNaN(prNum)) {
+    return { allowed: false, reason: `Invalid PR number "${gate.pr}". Use pr=<number> or pr=none.` };
+  }
   try {
-    const branch = detectBranch(command, cwd);
-    if (!branch || branch === "main" || branch === "master") return null;
-    const mergedCount = execSync(
-      `gh pr list --head "${branch}" --state merged --json number --jq length`,
-      { encoding: "utf-8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"] },
-    ).trim();
-    if (mergedCount && parseInt(mergedCount, 10) > 0) {
+    if (isPrMerged(gate.pr, gate.repo)) {
       return {
         allowed: false,
-        reason: `Branch "${branch}" already has a merged PR. Create a new branch from main (D-041: reusing old branches prohibited).`,
+        reason: `BLOCKED: PR #${gate.pr} in ${gate.repo} is already merged. Create a new branch from main.`,
       };
     }
   } catch {
-    // gh CLI not available or network error - fail open
+    // gh failed (network, CLI missing) - fail CLOSED for safety
+    return {
+      allowed: false,
+      reason: `Cannot verify PR #${gate.pr} status (gh CLI error). Check manually: gh pr view ${gate.pr} --repo ${gate.repo} --json state`,
+    };
   }
-  return null;
+  return null; // PR is open, allowed
 }
 
 /**
@@ -423,10 +442,12 @@ export function checkGit(rules: SafetyRules, command: string, cwd?: string, skip
       }
     }
   }
-  // Block commit/push to a branch that already has a merged PR.
+  // Require #!axme gate metadata on git commit and git push.
+  // The gate carries PR number and repo so the server can verify merge status
+  // without guessing cwd, branch, or remote. See D-086.
   // Skip if the command chain includes git checkout (branch will change before commit).
-  if (!skipMergedCheck && (stripped.startsWith("git push") || stripped.startsWith("git commit") || stripped.startsWith("git add"))) {
-    const verdict = checkMergedBranch(stripped, cwd);
+  if (!skipMergedCheck && (stripped.startsWith("git push") || stripped.startsWith("git commit"))) {
+    const verdict = checkAxmeGate(command); // use original command (with #!axme comment)
     if (verdict && !verdict.allowed) return verdict;
   }
   if (stripped.includes("reset --hard")) {

--- a/test/axme-gate.test.ts
+++ b/test/axme-gate.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseAxmeGate, checkGit } from "../src/storage/safety.js";
+import type { SafetyRules } from "../src/storage/safety.js";
+
+const defaultRules: SafetyRules = {
+  git: { protectedBranches: ["main", "master"], allowForcePush: false, allowDirectPushToMain: false },
+  bash: { deniedPrefixes: [], deniedCommands: [] },
+  filesystem: { deniedPaths: [] },
+};
+
+describe("parseAxmeGate", () => {
+  it("parses valid gate metadata", () => {
+    const result = parseAxmeGate('git commit -m "fix" #!axme pr=37 repo=AxmeAI/axme-code');
+    assert.deepEqual(result, { pr: "37", repo: "AxmeAI/axme-code" });
+  });
+
+  it("parses pr=none", () => {
+    const result = parseAxmeGate('git commit -m "init" #!axme pr=none repo=AxmeAI/axme-code');
+    assert.deepEqual(result, { pr: "none", repo: "AxmeAI/axme-code" });
+  });
+
+  it("returns null for no gate marker", () => {
+    assert.equal(parseAxmeGate('git commit -m "fix"'), null);
+  });
+
+  it("returns null for incomplete gate (missing repo)", () => {
+    assert.equal(parseAxmeGate('git commit -m "fix" #!axme pr=37'), null);
+  });
+
+  it("returns null for incomplete gate (missing pr)", () => {
+    assert.equal(parseAxmeGate('git commit -m "fix" #!axme repo=AxmeAI/axme-code'), null);
+  });
+
+  it("works with git push", () => {
+    const result = parseAxmeGate('git push -u origin feat/xxx #!axme pr=42 repo=AxmeAI/axme-cli');
+    assert.deepEqual(result, { pr: "42", repo: "AxmeAI/axme-cli" });
+  });
+
+  it("works with git -C path", () => {
+    const result = parseAxmeGate('git -C /path/to/repo commit -m "msg" #!axme pr=10 repo=AxmeAI/test');
+    assert.deepEqual(result, { pr: "10", repo: "AxmeAI/test" });
+  });
+});
+
+describe("checkGit with axme gate", () => {
+  it("blocks git commit without #!axme gate", () => {
+    const v = checkGit(defaultRules, 'git commit -m "test"');
+    assert.equal(v.allowed, false);
+    assert.ok(v.reason!.includes("#!axme"));
+    assert.ok(v.reason!.includes("BLOCKED"));
+  });
+
+  it("blocks git push without #!axme gate", () => {
+    const v = checkGit(defaultRules, "git push origin feat/xxx");
+    assert.equal(v.allowed, false);
+    assert.ok(v.reason!.includes("#!axme"));
+  });
+
+  it("allows git commit with pr=none", () => {
+    const v = checkGit(defaultRules, 'git commit -m "init" #!axme pr=none repo=AxmeAI/axme-code');
+    assert.equal(v.allowed, true);
+  });
+
+  it("allows git push with pr=none", () => {
+    const v = checkGit(defaultRules, 'git push -u origin feat/xxx #!axme pr=none repo=AxmeAI/axme-code');
+    assert.equal(v.allowed, true);
+  });
+
+  it("blocks invalid PR number", () => {
+    const v = checkGit(defaultRules, 'git commit -m "x" #!axme pr=abc repo=AxmeAI/axme-code');
+    assert.equal(v.allowed, false);
+    assert.ok(v.reason!.includes("Invalid PR number"));
+  });
+
+  it("does not require gate on git add", () => {
+    const v = checkGit(defaultRules, "git add src/file.ts");
+    assert.equal(v.allowed, true);
+  });
+
+  it("does not require gate on git status", () => {
+    const v = checkGit(defaultRules, "git status");
+    assert.equal(v.allowed, true);
+  });
+
+  it("does not require gate on git branch", () => {
+    const v = checkGit(defaultRules, "git branch --show-current");
+    assert.equal(v.allowed, true);
+  });
+
+  it("does not require gate on git diff", () => {
+    const v = checkGit(defaultRules, "git diff --stat");
+    assert.equal(v.allowed, true);
+  });
+
+  it("does not require gate on git log", () => {
+    const v = checkGit(defaultRules, "git log --oneline -5");
+    assert.equal(v.allowed, true);
+  });
+
+  it("skips gate check when skipMergedCheck is true", () => {
+    const v = checkGit(defaultRules, 'git commit -m "x"', undefined, true);
+    assert.equal(v.allowed, true);
+  });
+
+  it("still blocks force push even with valid gate", () => {
+    const v = checkGit(defaultRules, 'git push --force origin main #!axme pr=none repo=AxmeAI/axme-code');
+    assert.equal(v.allowed, false);
+    assert.ok(v.reason!.includes("Force push"));
+  });
+
+  it("still blocks direct push to main even with valid gate", () => {
+    const v = checkGit(defaultRules, 'git push origin main #!axme pr=none repo=AxmeAI/axme-code');
+    assert.equal(v.allowed, false);
+    assert.ok(v.reason!.includes("Direct push to main"));
+  });
+
+  it("works with git -C prefix", () => {
+    const v = checkGit(defaultRules, 'git -C /home/user/repo commit -m "fix" #!axme pr=none repo=AxmeAI/test');
+    assert.equal(v.allowed, true);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace fragile checkMergedBranch (cwd bug, fail-open, network dependent) with #!axme gate protocol
- Every git commit/push must include `#!axme pr=<number|none> repo=<owner/repo>` suffix
- Hook parses metadata, verifies PR not merged via `gh pr view --repo` (explicit repo, no cwd guessing)
- Fail-CLOSED: if gh check fails, command is blocked (not silently allowed)
- Agent instruction added to MCP server instructions so agents know the format upfront
- Removes detectBranch and checkMergedBranch (source of repeated bugs)

## Test plan
- [x] 21 new tests: parseAxmeGate parsing + checkGit integration
- [x] Blocks commit without gate, blocks push without gate
- [x] Allows pr=none, blocks invalid pr, blocks merged PR
- [x] Does NOT require gate on git add/status/branch/diff/log
- [x] Force push and direct-to-main checks still work with gate present
- [x] git -C prefix works with gate
- [x] Build + type check green
- [ ] E2E: reload MCP server, attempt git commit without gate, verify block message