### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## [0.2.0] - 2026-04-07
+
+### Added
+- **Context pagination**: MCP tool outputs split into pages (25K char limit) to prevent truncation. Affects `axme_context`, `axme_oracle`, `axme_decisions`, `axme_memories`. (#36)
+- **Auto-update**: Binary installs check GitHub releases on MCP server startup, download and replace automatically. 24h cache. Notification in `axme_context`. (#37)
+- **#!axme commit/push gate**: Every `git commit` and `git push` must include `#!axme pr=<number|none> repo=<owner/repo>` suffix. Hook verifies PR is not merged. Fail-closed on errors. (#38, #39)
+- **Tag/publish block**: `git tag`, `npm publish`, `twine upload`, `dotnet nuget push`, `mvn deploy`, `gh release create` blocked by safety hooks. Agent provides commands to user instead. (#41)
+- **Session close verification checklist**: Structured close flow with extraction checklist. (#34)
+- **144 tests**: Comprehensive test suite covering safety gate, bash safety, audit dedup, pagination, auto-update.
+
+### Fixed
+- **Duplicate sessions on reload**: Filesystem lock (O_EXCL) prevents parallel hooks from creating multiple AXME sessions per Claude session. (#40)
+- **Duplicate audit workers**: `cleanupAndExit` deduplicates by Claude session ID before spawning. Cross-session concurrent-audit check as defense-in-depth. (#40)
+- **Stuck audit logs**: `finally` block ensures audit log finalized. SIGTERM/SIGINT handlers in audit worker. (#40)
+- **Safety hook cwd bug**: Old `checkMergedBranch` ran `gh` without correct cwd, failing silently. Replaced entirely by #!axme gate. (#38)
+- **Install script unbound variable**: Fixed bash strict mode error on exit. (#22)
+- **Dependabot vulnerability**: Patched @anthropic-ai/sdk (GHSA-5474-4w2j-mq4c). (#22)
+
+### Changed
+- **Binary-only distribution**: Removed npm publish workflow. Install via `curl | bash` only. (#37)
+- **Compact KB format**: Save prompts produce self-contained descriptions. Compact `showDecisions` one-line format. (#26)
+- **Context split**: `axme_context` returns compact meta + instructions to load oracle/decisions/memories in parallel. (#24)
+- **Server-side dedup**: Repo context calls return only repo-specific data after workspace loaded. (#25)
+
+### Removed
+- `publish-npm.yml` workflow (binary-only distribution)
+- `axme_search_memory` tool (replaced by `axme_memories`)
+- `checkMergedBranch` / `detectBranch` (replaced by #!axme gate)
+- cd/pushd/cwd tracking in pre-tool-use hook (no longer needed with gate)
+
+## [0.1.0] - 2026-04-07
+
+Initial release.
+- MCP server with persistent memory, decisions, safety guardrails
+- Session tracking with background auditor
+- Safety hooks (pre-tool-use, post-tool-use)
+- Multi-repo workspace support
+- Binary installer (linux/macOS, x64/arm64)
+- npm package @axme/code

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axme/code",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Persistent memory, decisions, and safety guardrails for Claude Code",
   "type": "module",
   "main": "./dist/server.js",


### PR DESCRIPTION
## v0.2.0 Release

Version bump 0.1.0 -> 0.2.0 + CHANGELOG.

### Highlights (20 PRs since v0.1.0)
- Context pagination (25K char pages)
- Binary auto-update on MCP server startup
- #!axme commit/push gate protocol (replaces broken checkMergedBranch)
- Session dedup (filesystem lock, audit dedup by Claude session ID)
- Tag/publish command blocking in safety hooks
- 144 tests (from 0)

### After merge, run:
```bash
git tag v0.2.0
git push origin v0.2.0
```
This triggers the release-binary workflow (GitHub Release with 4 platform binaries).