### PR TITLE
feat: persistent backlog module with MCP tools

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -448,6 +448,66 @@ server.tool(
   },
 );
 
+// --- axme_backlog ---
+server.tool(
+  "axme_backlog",
+  "List or read backlog items. Persistent cross-session task tracking.",
+  {
+    project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    status: z.enum(["open", "in-progress", "done", "blocked"]).optional().describe("Filter by status. Omit to show all."),
+    id: z.string().optional().describe("Get a specific item by ID (e.g. B-001) or slug."),
+  },
+  async ({ project_path, status, id }) => {
+    const { showBacklog, getBacklogItem } = await import("./storage/backlog.js");
+    const resolved = pp(project_path);
+    if (id) {
+      const item = getBacklogItem(resolved, id);
+      if (!item) return { content: [{ type: "text" as const, text: `Backlog item "${id}" not found.` }] };
+      const tags = item.tags.length > 0 ? `\nTags: ${item.tags.join(", ")}` : "";
+      const notes = item.notes ? `\n\n## Notes\n${item.notes}` : "";
+      return { content: [{ type: "text" as const, text: `# ${item.id}: ${item.title}\n\nStatus: ${item.status} | Priority: ${item.priority} | Created: ${item.created} | Updated: ${item.updated}${tags}\n\n${item.description}${notes}` }] };
+    }
+    return { content: [{ type: "text" as const, text: showBacklog(resolved, status as any) }] };
+  },
+);
+
+// --- axme_backlog_add ---
+server.tool(
+  "axme_backlog_add",
+  "Add a new backlog item. Use for tasks, features, bugs that should persist across sessions.",
+  {
+    project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    title: z.string().describe("Short title for the backlog item"),
+    description: z.string().describe("Detailed description of the task/feature/bug"),
+    priority: z.enum(["high", "medium", "low"]).optional().describe("Priority level (default: medium)"),
+    tags: z.array(z.string()).optional().describe("Tags for categorization"),
+  },
+  async ({ project_path, title, description, priority, tags }) => {
+    const { addBacklogItem } = await import("./storage/backlog.js");
+    const item = addBacklogItem(pp(project_path), { title, description, priority: priority as any, tags });
+    return { content: [{ type: "text" as const, text: `Backlog item created: ${item.id} - ${item.title} (${item.priority})` }] };
+  },
+);
+
+// --- axme_backlog_update ---
+server.tool(
+  "axme_backlog_update",
+  "Update a backlog item status, priority, or add notes.",
+  {
+    project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    id: z.string().describe("Item ID (e.g. B-001) or slug"),
+    status: z.enum(["open", "in-progress", "done", "blocked"]).optional().describe("New status"),
+    priority: z.enum(["high", "medium", "low"]).optional().describe("New priority"),
+    notes: z.string().optional().describe("Additional notes to append"),
+  },
+  async ({ project_path, id, status, priority, notes }) => {
+    const { updateBacklogItem } = await import("./storage/backlog.js");
+    const item = updateBacklogItem(pp(project_path), id, { status: status as any, priority: priority as any, notes });
+    if (!item) return { content: [{ type: "text" as const, text: `Backlog item "${id}" not found.` }] };
+    return { content: [{ type: "text" as const, text: `Updated ${item.id}: ${item.title} -> ${item.status} (${item.priority})` }] };
+  },
+);
+
 // --- axme_status ---
 server.tool(
   "axme_status",

--- a/src/storage/backlog.ts
+++ b/src/storage/backlog.ts
@@ -1,0 +1,215 @@
+/**
+ * Backlog - persistent cross-session task tracking.
+ *
+ * Files: .axme-code/backlog/B-NNN-<slug>.md
+ *
+ * Unlike TodoWrite (ephemeral per-session), backlog items persist
+ * across sessions and are loaded into context at session start.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { atomicWrite, ensureDir, pathExists, removeFile, readSafe } from "./engine.js";
+import { AXME_CODE_DIR } from "../types.js";
+
+const BACKLOG_DIR = "backlog";
+
+export type BacklogStatus = "open" | "in-progress" | "done" | "blocked";
+export type BacklogPriority = "high" | "medium" | "low";
+
+export interface BacklogItem {
+  id: string;
+  slug: string;
+  title: string;
+  status: BacklogStatus;
+  priority: BacklogPriority;
+  description: string;
+  tags: string[];
+  created: string;
+  updated: string;
+  notes?: string;
+}
+
+// --- Public API ---
+
+export function initBacklogStore(projectPath: string): void {
+  ensureDir(backlogDir(projectPath));
+}
+
+export function addBacklogItem(
+  projectPath: string,
+  input: { title: string; description: string; priority?: BacklogPriority; tags?: string[] },
+): BacklogItem {
+  ensureDir(backlogDir(projectPath));
+  const existing = listBacklogItems(projectPath);
+  const nextNum = existing.length > 0
+    ? Math.max(...existing.map(d => parseInt(d.id.replace("B-", ""), 10) || 0)) + 1
+    : 1;
+  const id = `B-${String(nextNum).padStart(3, "0")}`;
+  const slug = toBacklogSlug(input.title);
+  const today = new Date().toISOString().slice(0, 10);
+  const item: BacklogItem = {
+    id,
+    slug,
+    title: input.title,
+    status: "open",
+    priority: input.priority ?? "medium",
+    description: input.description,
+    tags: input.tags ?? [],
+    created: today,
+    updated: today,
+  };
+  atomicWrite(itemPath(projectPath, id, slug), formatBacklogFile(item));
+  return item;
+}
+
+export function updateBacklogItem(
+  projectPath: string,
+  idOrSlug: string,
+  updates: { status?: BacklogStatus; priority?: BacklogPriority; notes?: string },
+): BacklogItem | null {
+  const item = getBacklogItem(projectPath, idOrSlug);
+  if (!item) return null;
+  if (updates.status) item.status = updates.status;
+  if (updates.priority) item.priority = updates.priority;
+  if (updates.notes) {
+    item.notes = item.notes
+      ? item.notes + "\n\n" + updates.notes
+      : updates.notes;
+  }
+  item.updated = new Date().toISOString().slice(0, 10);
+  atomicWrite(itemPath(projectPath, item.id, item.slug), formatBacklogFile(item));
+  return item;
+}
+
+export function listBacklogItems(projectPath: string, status?: BacklogStatus): BacklogItem[] {
+  const dir = backlogDir(projectPath);
+  if (!pathExists(dir)) return [];
+  const files = readdirSync(dir).filter(f => f.startsWith("B-") && f.endsWith(".md")).sort();
+  const items = files.map(f => parseBacklogFile(readFileSync(join(dir, f), "utf-8"))).filter(Boolean) as BacklogItem[];
+  if (status) return items.filter(i => i.status === status);
+  return items;
+}
+
+export function getBacklogItem(projectPath: string, idOrSlug: string): BacklogItem | null {
+  const items = listBacklogItems(projectPath);
+  const normalized = idOrSlug.toUpperCase();
+  return items.find(i => i.id === normalized || i.id === idOrSlug || i.slug === idOrSlug) ?? null;
+}
+
+export function backlogExists(projectPath: string): boolean {
+  return pathExists(backlogDir(projectPath));
+}
+
+export function backlogDir(projectPath: string): string {
+  return join(projectPath, AXME_CODE_DIR, BACKLOG_DIR);
+}
+
+/**
+ * Context string for axme_context: show count + high-priority open items.
+ */
+export function backlogContext(projectPath: string): string {
+  const items = listBacklogItems(projectPath);
+  if (items.length === 0) return "";
+  const open = items.filter(i => i.status === "open");
+  const inProgress = items.filter(i => i.status === "in-progress");
+  const blocked = items.filter(i => i.status === "blocked");
+  const done = items.filter(i => i.status === "done");
+
+  const lines = ["## Backlog", ""];
+  lines.push(`${open.length} open, ${inProgress.length} in-progress, ${blocked.length} blocked, ${done.length} done`);
+
+  // Show in-progress and high-priority open items inline
+  const urgent = [...inProgress, ...blocked, ...open.filter(i => i.priority === "high")];
+  if (urgent.length > 0) {
+    lines.push("");
+    for (const item of urgent.slice(0, 10)) {
+      const tag = item.status === "in-progress" ? "WIP" : item.status === "blocked" ? "BLOCKED" : "HIGH";
+      lines.push(`- [${tag}] ${item.id}: ${item.title}`);
+    }
+  }
+  if (open.length > urgent.filter(i => i.status === "open").length) {
+    lines.push(`- ... and ${open.length - urgent.filter(i => i.status === "open").length} more open items`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Full backlog display for axme_backlog tool.
+ */
+export function showBacklog(projectPath: string, status?: BacklogStatus): string {
+  const items = listBacklogItems(projectPath, status);
+  if (items.length === 0) return status ? `No ${status} backlog items.` : "No backlog items.";
+  return items.map(i => {
+    const tags = i.tags.length > 0 ? ` [${i.tags.join(", ")}]` : "";
+    const notes = i.notes ? `\n  Notes: ${i.notes.split("\n")[0]}...` : "";
+    return `- ${i.id}: ${i.title} (${i.status}, ${i.priority})${tags}${notes}`;
+  }).join("\n");
+}
+
+// --- Internal ---
+
+function itemPath(projectPath: string, id: string, slug: string): string {
+  return join(backlogDir(projectPath), `${id}-${slug}.md`);
+}
+
+export function toBacklogSlug(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 50);
+}
+
+function formatBacklogFile(item: BacklogItem): string {
+  const lines = [
+    "---",
+    `id: ${item.id}`,
+    `slug: ${item.slug}`,
+    `title: "${item.title.replace(/"/g, '\\"')}"`,
+    `status: ${item.status}`,
+    `priority: ${item.priority}`,
+    `tags: [${item.tags.map(t => `"${t}"`).join(", ")}]`,
+    `created: ${item.created}`,
+    `updated: ${item.updated}`,
+    "---",
+    "",
+    item.description,
+  ];
+  if (item.notes) {
+    lines.push("", "## Notes", "", item.notes);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function parseBacklogFile(content: string): BacklogItem | null {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) return null;
+  const fm = fmMatch[1];
+  const body = fmMatch[2].trim();
+
+  const get = (key: string): string => {
+    const m = fm.match(new RegExp(`^${key}:\\s*(.*)$`, "m"));
+    return m ? m[1].trim().replace(/^["']|["']$/g, "") : "";
+  };
+
+  const tagsMatch = fm.match(/^tags:\s*\[(.*)\]/m);
+  const tags = tagsMatch
+    ? tagsMatch[1].split(",").map(t => t.trim().replace(/^["']|["']$/g, "")).filter(Boolean)
+    : [];
+
+  // Split body into description and notes
+  const notesIdx = body.indexOf("## Notes");
+  const description = notesIdx >= 0 ? body.slice(0, notesIdx).trim() : body;
+  const notes = notesIdx >= 0 ? body.slice(notesIdx + "## Notes".length).trim() : undefined;
+
+  return {
+    id: get("id"),
+    slug: get("slug"),
+    title: get("title"),
+    status: (get("status") || "open") as BacklogStatus,
+    priority: (get("priority") || "medium") as BacklogPriority,
+    description,
+    tags,
+    created: get("created"),
+    updated: get("updated"),
+    notes,
+  };
+}

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -18,6 +18,7 @@ import { plansContext, handoffContext } from "../storage/plans.js";
 import { listPendingAudits } from "../storage/sessions.js";
 import { detectWorkspace } from "../utils/workspace-detector.js";
 import { questionsContext } from "../storage/questions.js";
+import { backlogContext } from "../storage/backlog.js";
 
 /**
  * Build the authoritative "Storage root" header that is prepended to every
@@ -107,6 +108,12 @@ export function getFullContextSections(projectPath: string, workspacePath?: stri
   // Active plans (small)
   const plans = plansContext(projectPath);
   if (plans) parts.push(plans);
+
+  // Backlog summary
+  try {
+    const bl = backlogContext(workspacePath ?? projectPath);
+    if (bl) parts.push(bl);
+  } catch {}
 
   // Open questions
   try {

--- a/test/backlog.test.ts
+++ b/test/backlog.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  initBacklogStore,
+  addBacklogItem,
+  updateBacklogItem,
+  listBacklogItems,
+  getBacklogItem,
+  backlogContext,
+  showBacklog,
+  toBacklogSlug,
+} from "../src/storage/backlog.js";
+
+const TEST_ROOT = "/tmp/axme-backlog-test";
+
+function setup() {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+  mkdirSync(join(TEST_ROOT, ".axme-code"), { recursive: true });
+  initBacklogStore(TEST_ROOT);
+}
+
+function cleanup() {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+}
+
+describe("addBacklogItem", () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it("creates B-001 with correct fields", () => {
+    const item = addBacklogItem(TEST_ROOT, { title: "Fix auth bug", description: "JWT expiry broken" });
+    assert.equal(item.id, "B-001");
+    assert.equal(item.title, "Fix auth bug");
+    assert.equal(item.status, "open");
+    assert.equal(item.priority, "medium");
+    assert.equal(item.description, "JWT expiry broken");
+  });
+
+  it("auto-increments IDs", () => {
+    const a = addBacklogItem(TEST_ROOT, { title: "First", description: "d1" });
+    const b = addBacklogItem(TEST_ROOT, { title: "Second", description: "d2" });
+    const c = addBacklogItem(TEST_ROOT, { title: "Third", description: "d3" });
+    assert.equal(a.id, "B-001");
+    assert.equal(b.id, "B-002");
+    assert.equal(c.id, "B-003");
+  });
+
+  it("uses provided priority", () => {
+    const item = addBacklogItem(TEST_ROOT, { title: "Urgent", description: "d", priority: "high" });
+    assert.equal(item.priority, "high");
+  });
+
+  it("uses provided tags", () => {
+    const item = addBacklogItem(TEST_ROOT, { title: "Tagged", description: "d", tags: ["auth", "security"] });
+    assert.deepEqual(item.tags, ["auth", "security"]);
+  });
+});
+
+describe("listBacklogItems", () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it("returns all items", () => {
+    addBacklogItem(TEST_ROOT, { title: "A", description: "d" });
+    addBacklogItem(TEST_ROOT, { title: "B", description: "d" });
+    assert.equal(listBacklogItems(TEST_ROOT).length, 2);
+  });
+
+  it("filters by status", () => {
+    addBacklogItem(TEST_ROOT, { title: "Open", description: "d" });
+    const item = addBacklogItem(TEST_ROOT, { title: "WIP", description: "d" });
+    updateBacklogItem(TEST_ROOT, item.id, { status: "in-progress" });
+    assert.equal(listBacklogItems(TEST_ROOT, "open").length, 1);
+    assert.equal(listBacklogItems(TEST_ROOT, "in-progress").length, 1);
+  });
+
+  it("returns empty for no items", () => {
+    assert.equal(listBacklogItems(TEST_ROOT).length, 0);
+  });
+});
+
+describe("getBacklogItem", () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it("finds by ID", () => {
+    addBacklogItem(TEST_ROOT, { title: "Find me", description: "d" });
+    const item = getBacklogItem(TEST_ROOT, "B-001");
+    assert.equal(item?.title, "Find me");
+  });
+
+  it("finds by slug", () => {
+    const created = addBacklogItem(TEST_ROOT, { title: "Find by slug", description: "d" });
+    const item = getBacklogItem(TEST_ROOT, created.slug);
+    assert.equal(item?.id, "B-001");
+  });
+
+  it("returns null for missing", () => {
+    assert.equal(getBacklogItem(TEST_ROOT, "B-999"), null);
+  });
+});
+
+describe("updateBacklogItem", () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it("updates status", () => {
+    addBacklogItem(TEST_ROOT, { title: "Task", description: "d" });
+    const updated = updateBacklogItem(TEST_ROOT, "B-001", { status: "in-progress" });
+    assert.equal(updated?.status, "in-progress");
+    // Verify persisted
+    const reread = getBacklogItem(TEST_ROOT, "B-001");
+    assert.equal(reread?.status, "in-progress");
+  });
+
+  it("updates priority", () => {
+    addBacklogItem(TEST_ROOT, { title: "Task", description: "d" });
+    const updated = updateBacklogItem(TEST_ROOT, "B-001", { priority: "high" });
+    assert.equal(updated?.priority, "high");
+  });
+
+  it("appends notes", () => {
+    addBacklogItem(TEST_ROOT, { title: "Task", description: "d" });
+    updateBacklogItem(TEST_ROOT, "B-001", { notes: "First note" });
+    updateBacklogItem(TEST_ROOT, "B-001", { notes: "Second note" });
+    const item = getBacklogItem(TEST_ROOT, "B-001");
+    assert.ok(item?.notes?.includes("First note"));
+    assert.ok(item?.notes?.includes("Second note"));
+  });
+
+  it("returns null for missing item", () => {
+    assert.equal(updateBacklogItem(TEST_ROOT, "B-999", { status: "done" }), null);
+  });
+
+  it("updates the updated date", () => {
+    const created = addBacklogItem(TEST_ROOT, { title: "Task", description: "d" });
+    const originalDate = created.updated;
+    const updated = updateBacklogItem(TEST_ROOT, "B-001", { status: "done" });
+    assert.ok(updated?.updated);
+    // Same day in test, but field is set
+    assert.equal(typeof updated?.updated, "string");
+  });
+});
+
+describe("backlogContext", () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it("returns empty for no items", () => {
+    assert.equal(backlogContext(TEST_ROOT), "");
+  });
+
+  it("shows counts", () => {
+    addBacklogItem(TEST_ROOT, { title: "Open1", description: "d" });
+    addBacklogItem(TEST_ROOT, { title: "Open2", description: "d" });
+    const ctx = backlogContext(TEST_ROOT);
+    assert.ok(ctx.includes("2 open"));
+    assert.ok(ctx.includes("## Backlog"));
+  });
+
+  it("highlights in-progress items", () => {
+    const item = addBacklogItem(TEST_ROOT, { title: "WIP task", description: "d" });
+    updateBacklogItem(TEST_ROOT, item.id, { status: "in-progress" });
+    const ctx = backlogContext(TEST_ROOT);
+    assert.ok(ctx.includes("[WIP]"));
+    assert.ok(ctx.includes("WIP task"));
+  });
+
+  it("highlights high-priority items", () => {
+    addBacklogItem(TEST_ROOT, { title: "Urgent fix", description: "d", priority: "high" });
+    const ctx = backlogContext(TEST_ROOT);
+    assert.ok(ctx.includes("[HIGH]"));
+    assert.ok(ctx.includes("Urgent fix"));
+  });
+});
+
+describe("showBacklog", () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it("shows all items formatted", () => {
+    addBacklogItem(TEST_ROOT, { title: "Task A", description: "d", tags: ["auth"] });
+    addBacklogItem(TEST_ROOT, { title: "Task B", description: "d" });
+    const output = showBacklog(TEST_ROOT);
+    assert.ok(output.includes("B-001"));
+    assert.ok(output.includes("Task A"));
+    assert.ok(output.includes("[auth]"));
+    assert.ok(output.includes("B-002"));
+  });
+
+  it("shows message for empty backlog", () => {
+    assert.ok(showBacklog(TEST_ROOT).includes("No backlog items"));
+  });
+
+  it("filters by status", () => {
+    addBacklogItem(TEST_ROOT, { title: "Open", description: "d" });
+    const item = addBacklogItem(TEST_ROOT, { title: "Done", description: "d" });
+    updateBacklogItem(TEST_ROOT, item.id, { status: "done" });
+    const output = showBacklog(TEST_ROOT, "done");
+    assert.ok(output.includes("Done"));
+    assert.ok(!output.includes("Open"));
+  });
+});
+
+describe("toBacklogSlug", () => {
+  it("converts to lowercase", () => {
+    assert.equal(toBacklogSlug("Fix Auth Bug"), "fix-auth-bug");
+  });
+
+  it("removes special characters", () => {
+    assert.equal(toBacklogSlug("Fix: auth (JWT)!"), "fix-auth-jwt");
+  });
+
+  it("max 50 characters", () => {
+    const long = "a".repeat(100);
+    assert.ok(toBacklogSlug(long).length <= 50);
+  });
+});


### PR DESCRIPTION
## Summary
Persistent cross-session task tracking. Unlike TodoWrite (ephemeral per-session), backlog items survive sessions.

**Storage:** `.axme-code/backlog/B-NNN-<slug>.md` with frontmatter (status, priority, tags, notes)

**MCP tools:**
- `axme_backlog` - list/read (filter by status, get by ID/slug)
- `axme_backlog_add` - create new item
- `axme_backlog_update` - change status/priority, append notes

**Context integration:** `axme_context` shows backlog summary (counts + WIP/HIGH/BLOCKED)

## Test plan
- [x] 25 new tests (add, list, get, update, status filter, notes append, context, slug)
- [x] 303 total tests green
- [x] Build + type check clean