### PR TITLE
feat: persistent backlog module with scope support

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -448,6 +448,69 @@ server.tool(
   },
 );
 
+// --- axme_backlog ---
+server.tool(
+  "axme_backlog",
+  "List or read backlog items. Persistent cross-session task tracking.",
+  {
+    project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    status: z.enum(["open", "in-progress", "done", "blocked"]).optional().describe("Filter by status. Omit to show all."),
+    id: z.string().optional().describe("Get a specific item by ID (e.g. B-001) or slug."),
+  },
+  async ({ project_path, status, id }) => {
+    const { showBacklog, getBacklogItem } = await import("./storage/backlog.js");
+    const resolved = pp(project_path);
+    if (id) {
+      const item = getBacklogItem(resolved, id);
+      if (!item) return { content: [{ type: "text" as const, text: `Backlog item "${id}" not found.` }] };
+      const tags = item.tags.length > 0 ? `\nTags: ${item.tags.join(", ")}` : "";
+      const scope = item.scope?.length ? `\nScope: ${item.scope.join(", ")}` : "";
+      const notes = item.notes ? `\n\n## Notes\n${item.notes}` : "";
+      return { content: [{ type: "text" as const, text: `# ${item.id}: ${item.title}\n\nStatus: ${item.status} | Priority: ${item.priority} | Created: ${item.created} | Updated: ${item.updated}${tags}${scope}\n\n${item.description}${notes}` }] };
+    }
+    return { content: [{ type: "text" as const, text: showBacklog(resolved, status as any) }] };
+  },
+);
+
+// --- axme_backlog_add ---
+server.tool(
+  "axme_backlog_add",
+  "Add a new backlog item. Use for tasks, features, bugs that should persist across sessions.",
+  {
+    project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    title: z.string().describe("Short title for the backlog item"),
+    description: z.string().describe("Detailed description of the task/feature/bug"),
+    priority: z.enum(["high", "medium", "low"]).optional().describe("Priority level (default: medium)"),
+    tags: z.array(z.string()).optional().describe("Tags for categorization"),
+    scope: z.array(z.string()).optional().describe("Project scope (e.g. [\"all\"] for workspace, [\"repo-name\"] for specific repo)"),
+  },
+  async ({ project_path, title, description, priority, tags, scope }) => {
+    const { addBacklogItem } = await import("./storage/backlog.js");
+    const resolved = ppWithScope(project_path, scope);
+    const item = addBacklogItem(resolved, { title, description, priority: priority as any, tags, scope });
+    return { content: [{ type: "text" as const, text: `Backlog item created: ${item.id} - ${item.title} (${item.priority})` }] };
+  },
+);
+
+// --- axme_backlog_update ---
+server.tool(
+  "axme_backlog_update",
+  "Update a backlog item status, priority, or add notes.",
+  {
+    project_path: z.string().optional().describe("Absolute path to the project root (defaults to server cwd)"),
+    id: z.string().describe("Item ID (e.g. B-001) or slug"),
+    status: z.enum(["open", "in-progress", "done", "blocked"]).optional().describe("New status"),
+    priority: z.enum(["high", "medium", "low"]).optional().describe("New priority"),
+    notes: z.string().optional().describe("Additional notes to append"),
+  },
+  async ({ project_path, id, status, priority, notes }) => {
+    const { updateBacklogItem } = await import("./storage/backlog.js");
+    const item = updateBacklogItem(pp(project_path), id, { status: status as any, priority: priority as any, notes });
+    if (!item) return { content: [{ type: "text" as const, text: `Backlog item "${id}" not found.` }] };
+    return { content: [{ type: "text" as const, text: `Updated ${item.id}: ${item.title} -> ${item.status} (${item.priority})` }] };
+  },
+);
+
 // --- axme_status ---
 server.tool(
   "axme_status",

--- a/src/storage/backlog.ts
+++ b/src/storage/backlog.ts
@@ -1,0 +1,219 @@
+/**
+ * Backlog - persistent cross-session task tracking.
+ *
+ * Files: .axme-code/backlog/B-NNN-<slug>.md
+ *
+ * Unlike TodoWrite (ephemeral per-session), backlog items persist
+ * across sessions and are loaded into context at session start.
+ *
+ * Scope: items can be stored at workspace level (scope: ["all"])
+ * or repo level (scope: ["repo-name"]), same as decisions/memories.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { atomicWrite, ensureDir, pathExists } from "./engine.js";
+import { AXME_CODE_DIR } from "../types.js";
+
+const BACKLOG_DIR = "backlog";
+
+export type BacklogStatus = "open" | "in-progress" | "done" | "blocked";
+export type BacklogPriority = "high" | "medium" | "low";
+
+export interface BacklogItem {
+  id: string;
+  slug: string;
+  title: string;
+  status: BacklogStatus;
+  priority: BacklogPriority;
+  description: string;
+  tags: string[];
+  created: string;
+  updated: string;
+  notes?: string;
+  scope?: string[];
+}
+
+// --- Public API ---
+
+export function initBacklogStore(projectPath: string): void {
+  ensureDir(backlogDir(projectPath));
+}
+
+export function addBacklogItem(
+  projectPath: string,
+  input: { title: string; description: string; priority?: BacklogPriority; tags?: string[]; scope?: string[] },
+): BacklogItem {
+  ensureDir(backlogDir(projectPath));
+  const existing = listBacklogItems(projectPath);
+  const nextNum = existing.length > 0
+    ? Math.max(...existing.map(d => parseInt(d.id.replace("B-", ""), 10) || 0)) + 1
+    : 1;
+  const id = `B-${String(nextNum).padStart(3, "0")}`;
+  const slug = toBacklogSlug(input.title);
+  const now = new Date().toISOString().slice(0, 19).replace("T", " ") + " UTC";
+  const item: BacklogItem = {
+    id,
+    slug,
+    title: input.title,
+    status: "open",
+    priority: input.priority ?? "medium",
+    description: input.description,
+    tags: input.tags ?? [],
+    created: now,
+    updated: now,
+    scope: input.scope,
+  };
+  atomicWrite(itemPath(projectPath, id, slug), formatBacklogFile(item));
+  return item;
+}
+
+export function updateBacklogItem(
+  projectPath: string,
+  idOrSlug: string,
+  updates: { status?: BacklogStatus; priority?: BacklogPriority; notes?: string },
+): BacklogItem | null {
+  const item = getBacklogItem(projectPath, idOrSlug);
+  if (!item) return null;
+  if (updates.status) item.status = updates.status;
+  if (updates.priority) item.priority = updates.priority;
+  if (updates.notes) {
+    item.notes = item.notes
+      ? item.notes + "\n\n" + updates.notes
+      : updates.notes;
+  }
+  item.updated = new Date().toISOString().slice(0, 19).replace("T", " ") + " UTC";
+  atomicWrite(itemPath(projectPath, item.id, item.slug), formatBacklogFile(item));
+  return item;
+}
+
+export function listBacklogItems(projectPath: string, status?: BacklogStatus): BacklogItem[] {
+  const dir = backlogDir(projectPath);
+  if (!pathExists(dir)) return [];
+  const files = readdirSync(dir).filter(f => f.startsWith("B-") && f.endsWith(".md")).sort();
+  const items = files.map(f => parseBacklogFile(readFileSync(join(dir, f), "utf-8"))).filter(Boolean) as BacklogItem[];
+  if (status) return items.filter(i => i.status === status);
+  return items;
+}
+
+export function getBacklogItem(projectPath: string, idOrSlug: string): BacklogItem | null {
+  const items = listBacklogItems(projectPath);
+  const normalized = idOrSlug.toUpperCase();
+  return items.find(i => i.id === normalized || i.id === idOrSlug || i.slug === idOrSlug) ?? null;
+}
+
+export function backlogExists(projectPath: string): boolean {
+  return pathExists(backlogDir(projectPath));
+}
+
+export function backlogDir(projectPath: string): string {
+  return join(projectPath, AXME_CODE_DIR, BACKLOG_DIR);
+}
+
+/**
+ * Context string for axme_context: show count + high-priority open items.
+ */
+export function backlogContext(projectPath: string): string {
+  const items = listBacklogItems(projectPath);
+  if (items.length === 0) return "";
+  const open = items.filter(i => i.status === "open");
+  const inProgress = items.filter(i => i.status === "in-progress");
+  const blocked = items.filter(i => i.status === "blocked");
+  const done = items.filter(i => i.status === "done");
+
+  const lines = ["## Backlog", ""];
+  lines.push(`${open.length} open, ${inProgress.length} in-progress, ${blocked.length} blocked, ${done.length} done`);
+
+  const urgent = [...inProgress, ...blocked, ...open.filter(i => i.priority === "high")];
+  if (urgent.length > 0) {
+    lines.push("");
+    for (const item of urgent.slice(0, 10)) {
+      const tag = item.status === "in-progress" ? "WIP" : item.status === "blocked" ? "BLOCKED" : "HIGH";
+      lines.push(`- [${tag}] ${item.id}: ${item.title}`);
+    }
+  }
+  if (open.length > urgent.filter(i => i.status === "open").length) {
+    lines.push(`- ... and ${open.length - urgent.filter(i => i.status === "open").length} more open items`);
+  }
+
+  return lines.join("\n");
+}
+
+export function showBacklog(projectPath: string, status?: BacklogStatus): string {
+  const items = listBacklogItems(projectPath, status);
+  if (items.length === 0) return status ? `No ${status} backlog items.` : "No backlog items.";
+  return items.map(i => {
+    const tags = i.tags.length > 0 ? ` [${i.tags.join(", ")}]` : "";
+    const notes = i.notes ? `\n  Notes: ${i.notes.split("\n")[0]}...` : "";
+    return `- ${i.id}: ${i.title} (${i.status}, ${i.priority})${tags}${notes}`;
+  }).join("\n");
+}
+
+// --- Internal ---
+
+function itemPath(projectPath: string, id: string, slug: string): string {
+  return join(backlogDir(projectPath), `${id}-${slug}.md`);
+}
+
+export function toBacklogSlug(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 50);
+}
+
+function formatBacklogFile(item: BacklogItem): string {
+  const lines = [
+    "---",
+    `id: ${item.id}`,
+    `slug: ${item.slug}`,
+    `title: "${item.title.replace(/"/g, '\\"')}"`,
+    `status: ${item.status}`,
+    `priority: ${item.priority}`,
+    `tags: [${item.tags.map(t => `"${t}"`).join(", ")}]`,
+    `created: ${item.created}`,
+    `updated: ${item.updated}`,
+    ...(item.scope?.length ? [`scope: [${item.scope.map(s => `"${s}"`).join(", ")}]`] : []),
+    "---",
+    "",
+    item.description,
+  ];
+  if (item.notes) {
+    lines.push("", "## Notes", "", item.notes);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function parseBacklogFile(content: string): BacklogItem | null {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) return null;
+  const fm = fmMatch[1];
+  const body = fmMatch[2].trim();
+
+  const get = (key: string): string => {
+    const m = fm.match(new RegExp(`^${key}:\\s*(.*)$`, "m"));
+    return m ? m[1].trim().replace(/^["']|["']$/g, "") : "";
+  };
+
+  const parseArray = (key: string): string[] => {
+    const m = fm.match(new RegExp(`^${key}:\\s*\\[(.*)\\]`, "m"));
+    return m ? m[1].split(",").map(t => t.trim().replace(/^["']|["']$/g, "")).filter(Boolean) : [];
+  };
+  const tags = parseArray("tags");
+  const scope = parseArray("scope");
+
+  const notesIdx = body.indexOf("## Notes");
+  const description = notesIdx >= 0 ? body.slice(0, notesIdx).trim() : body;
+  const notes = notesIdx >= 0 ? body.slice(notesIdx + "## Notes".length).trim() : undefined;
+
+  return {
+    id: get("id"),
+    slug: get("slug"),
+    title: get("title"),
+    status: (get("status") || "open") as BacklogStatus,
+    priority: (get("priority") || "medium") as BacklogPriority,
+    description,
+    tags,
+    created: get("created"),
+    updated: get("updated"),
+    notes,
+    scope: scope.length > 0 ? scope : undefined,
+  };
+}

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -18,6 +18,7 @@ import { plansContext, handoffContext } from "../storage/plans.js";
 import { listPendingAudits } from "../storage/sessions.js";
 import { detectWorkspace } from "../utils/workspace-detector.js";
 import { questionsContext } from "../storage/questions.js";
+import { backlogContext } from "../storage/backlog.js";
 
 /**
  * Build the authoritative "Storage root" header that is prepended to every
@@ -107,6 +108,12 @@ export function getFullContextSections(projectPath: string, workspacePath?: stri
   // Active plans (small)
   const plans = plansContext(projectPath);
   if (plans) parts.push(plans);
+
+  // Backlog summary
+  try {
+    const bl = backlogContext(workspacePath ?? projectPath);
+    if (bl) parts.push(bl);
+  } catch {}
 
   // Open questions
   try {

--- a/test/backlog.test.ts
+++ b/test/backlog.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  initBacklogStore, addBacklogItem, updateBacklogItem,
+  listBacklogItems, getBacklogItem, backlogContext,
+  showBacklog, toBacklogSlug,
+} from "../src/storage/backlog.js";
+
+const TEST_ROOT = "/tmp/axme-backlog-test";
+function setup() { rmSync(TEST_ROOT, { recursive: true, force: true }); mkdirSync(join(TEST_ROOT, ".axme-code"), { recursive: true }); initBacklogStore(TEST_ROOT); }
+function cleanup() { rmSync(TEST_ROOT, { recursive: true, force: true }); }
+
+describe("addBacklogItem", () => {
+  beforeEach(setup); afterEach(cleanup);
+  it("creates B-001", () => { const i = addBacklogItem(TEST_ROOT, { title: "Fix bug", description: "d" }); assert.equal(i.id, "B-001"); assert.equal(i.status, "open"); assert.equal(i.priority, "medium"); });
+  it("auto-increments", () => { addBacklogItem(TEST_ROOT, { title: "A", description: "d" }); const b = addBacklogItem(TEST_ROOT, { title: "B", description: "d" }); assert.equal(b.id, "B-002"); });
+  it("uses provided priority", () => { const i = addBacklogItem(TEST_ROOT, { title: "U", description: "d", priority: "high" }); assert.equal(i.priority, "high"); });
+  it("uses provided tags", () => { const i = addBacklogItem(TEST_ROOT, { title: "T", description: "d", tags: ["auth"] }); assert.deepEqual(i.tags, ["auth"]); });
+  it("uses provided scope", () => { const i = addBacklogItem(TEST_ROOT, { title: "S", description: "d", scope: ["all"] }); assert.deepEqual(i.scope, ["all"]); });
+  it("timestamps include time and UTC", () => { const i = addBacklogItem(TEST_ROOT, { title: "T", description: "d" }); assert.ok(i.created.includes("UTC")); assert.ok(i.created.includes(":")); });
+});
+
+describe("listBacklogItems", () => {
+  beforeEach(setup); afterEach(cleanup);
+  it("returns all", () => { addBacklogItem(TEST_ROOT, { title: "A", description: "d" }); addBacklogItem(TEST_ROOT, { title: "B", description: "d" }); assert.equal(listBacklogItems(TEST_ROOT).length, 2); });
+  it("filters by status", () => { addBacklogItem(TEST_ROOT, { title: "O", description: "d" }); const i = addBacklogItem(TEST_ROOT, { title: "W", description: "d" }); updateBacklogItem(TEST_ROOT, i.id, { status: "in-progress" }); assert.equal(listBacklogItems(TEST_ROOT, "open").length, 1); assert.equal(listBacklogItems(TEST_ROOT, "in-progress").length, 1); });
+  it("empty returns []", () => { assert.equal(listBacklogItems(TEST_ROOT).length, 0); });
+});
+
+describe("getBacklogItem", () => {
+  beforeEach(setup); afterEach(cleanup);
+  it("by ID", () => { addBacklogItem(TEST_ROOT, { title: "Find", description: "d" }); assert.equal(getBacklogItem(TEST_ROOT, "B-001")?.title, "Find"); });
+  it("by slug", () => { const c = addBacklogItem(TEST_ROOT, { title: "By Slug", description: "d" }); assert.equal(getBacklogItem(TEST_ROOT, c.slug)?.id, "B-001"); });
+  it("null for missing", () => { assert.equal(getBacklogItem(TEST_ROOT, "B-999"), null); });
+});
+
+describe("updateBacklogItem", () => {
+  beforeEach(setup); afterEach(cleanup);
+  it("updates status", () => { addBacklogItem(TEST_ROOT, { title: "T", description: "d" }); const u = updateBacklogItem(TEST_ROOT, "B-001", { status: "done" }); assert.equal(u?.status, "done"); assert.equal(getBacklogItem(TEST_ROOT, "B-001")?.status, "done"); });
+  it("updates priority", () => { addBacklogItem(TEST_ROOT, { title: "T", description: "d" }); assert.equal(updateBacklogItem(TEST_ROOT, "B-001", { priority: "high" })?.priority, "high"); });
+  it("appends notes", () => { addBacklogItem(TEST_ROOT, { title: "T", description: "d" }); updateBacklogItem(TEST_ROOT, "B-001", { notes: "N1" }); updateBacklogItem(TEST_ROOT, "B-001", { notes: "N2" }); const i = getBacklogItem(TEST_ROOT, "B-001"); assert.ok(i?.notes?.includes("N1")); assert.ok(i?.notes?.includes("N2")); });
+  it("null for missing", () => { assert.equal(updateBacklogItem(TEST_ROOT, "B-999", { status: "done" }), null); });
+  it("updates timestamp with UTC", () => { addBacklogItem(TEST_ROOT, { title: "T", description: "d" }); const u = updateBacklogItem(TEST_ROOT, "B-001", { status: "done" }); assert.ok(u?.updated.includes("UTC")); });
+});
+
+describe("backlogContext", () => {
+  beforeEach(setup); afterEach(cleanup);
+  it("empty returns ''", () => { assert.equal(backlogContext(TEST_ROOT), ""); });
+  it("shows counts", () => { addBacklogItem(TEST_ROOT, { title: "A", description: "d" }); addBacklogItem(TEST_ROOT, { title: "B", description: "d" }); const c = backlogContext(TEST_ROOT); assert.ok(c.includes("2 open")); assert.ok(c.includes("## Backlog")); });
+  it("highlights WIP", () => { const i = addBacklogItem(TEST_ROOT, { title: "WIP", description: "d" }); updateBacklogItem(TEST_ROOT, i.id, { status: "in-progress" }); assert.ok(backlogContext(TEST_ROOT).includes("[WIP]")); });
+  it("highlights HIGH", () => { addBacklogItem(TEST_ROOT, { title: "Urgent", description: "d", priority: "high" }); assert.ok(backlogContext(TEST_ROOT).includes("[HIGH]")); });
+});
+
+describe("showBacklog", () => {
+  beforeEach(setup); afterEach(cleanup);
+  it("shows all formatted", () => { addBacklogItem(TEST_ROOT, { title: "Task A", description: "d", tags: ["auth"] }); const o = showBacklog(TEST_ROOT); assert.ok(o.includes("B-001")); assert.ok(o.includes("[auth]")); });
+  it("empty message", () => { assert.ok(showBacklog(TEST_ROOT).includes("No backlog")); });
+  it("filters by status", () => { addBacklogItem(TEST_ROOT, { title: "O", description: "d" }); const i = addBacklogItem(TEST_ROOT, { title: "D", description: "d" }); updateBacklogItem(TEST_ROOT, i.id, { status: "done" }); const o = showBacklog(TEST_ROOT, "done"); assert.ok(o.includes("D")); assert.ok(!o.includes(", open,")); });
+});
+
+describe("toBacklogSlug", () => {
+  it("lowercase", () => { assert.equal(toBacklogSlug("Fix Auth Bug"), "fix-auth-bug"); });
+  it("removes special chars", () => { assert.equal(toBacklogSlug("Fix: auth (JWT)!"), "fix-auth-jwt"); });
+  it("max 50 chars", () => { assert.ok(toBacklogSlug("a".repeat(100)).length <= 50); });
+});
+
+describe("scope persistence", () => {
+  beforeEach(setup); afterEach(cleanup);
+  it("scope round-trips through file", () => { addBacklogItem(TEST_ROOT, { title: "Scoped", description: "d", scope: ["axme-code"] }); const i = getBacklogItem(TEST_ROOT, "B-001"); assert.deepEqual(i?.scope, ["axme-code"]); });
+  it("scope: all round-trips", () => { addBacklogItem(TEST_ROOT, { title: "Global", description: "d", scope: ["all"] }); assert.deepEqual(getBacklogItem(TEST_ROOT, "B-001")?.scope, ["all"]); });
+  it("no scope -> undefined", () => { addBacklogItem(TEST_ROOT, { title: "Local", description: "d" }); assert.equal(getBacklogItem(TEST_ROOT, "B-001")?.scope, undefined); });
+});


### PR DESCRIPTION
## Summary
Persistent cross-session task tracking with workspace/repo scope.

- Storage: `.axme-code/backlog/B-NNN-<slug>.md`
- Scope: `scope: ["all"]` for workspace, `scope: ["repo-name"]` for repo, omit for default
- Datetime timestamps with UTC (not date-only)
- MCP tools: `axme_backlog`, `axme_backlog_add`, `axme_backlog_update`
- Context: `axme_context` shows backlog summary (counts + WIP/HIGH/BLOCKED)

## Test plan
- [x] 30 new tests (CRUD, scope round-trip, timestamps, context formatting)
- [x] 308 total tests green
- [x] Build + type check clean
- [ ] E2E: reload, add item via MCP tool, verify on disk