### PR TITLE
fix: backlogContext reads from projectPath

### DIFF
--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -111,7 +111,7 @@ export function getFullContextSections(projectPath: string, workspacePath?: stri
 
   // Backlog summary
   try {
-    const bl = backlogContext(workspacePath ?? projectPath);
+    const bl = backlogContext(projectPath);
     if (bl) parts.push(bl);
   } catch {}
 


### PR DESCRIPTION
One-line fix: backlog summary in axme_context uses projectPath (current repo) not workspacePath.