### PR TITLE
fix: repo-launched MCP server forces repo mode (D-116)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -264,8 +264,9 @@ async function main() {
   switch (command) {
     case "setup": {
       const projectPath = resolve(args[1] || ".");
+      const hasGitDir = existsSync(join(projectPath, ".git"));
       const ws = detectWorkspace(projectPath);
-      const isWorkspace = ws.type !== "single";
+      const isWorkspace = hasGitDir ? false : ws.type !== "single";
 
       if (isWorkspace) {
         console.log(`Initializing AXME Code workspace in ${projectPath} (${ws.type}, ${ws.projects.length} projects)...`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@
  */
 
 import { join } from "node:path";
+import { existsSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -40,8 +41,9 @@ import { spawnDetachedAuditWorker } from "./audit-spawner.js";
 // --- Server state (detected at startup from cwd) ---
 
 const serverCwd = process.cwd();
+const serverHasGit = existsSync(join(serverCwd, ".git"));
 const serverWorkspace = detectWorkspace(serverCwd);
-const isWorkspace = serverWorkspace.type !== "single";
+const isWorkspace = serverHasGit ? false : serverWorkspace.type !== "single";
 const defaultProjectPath = serverCwd;
 const defaultWorkspacePath = isWorkspace ? serverCwd : null;
 

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -9,6 +9,7 @@ import { oracleContext, showOracle, oracleExists, loadOracleFiles } from "../sto
 import { decisionsContext, showDecisions, enforceableDecisionsContext, listDecisions } from "../storage/decisions.js";
 import { pathExists, readSafe } from "../storage/engine.js";
 import { join } from "node:path";
+import { existsSync } from "node:fs";
 import { AXME_CODE_DIR } from "../types.js";
 import { safetyContext, loadSafetyRules } from "../storage/safety.js";
 import { allMemoryContext, listMemories } from "../storage/memory.js";
@@ -35,7 +36,8 @@ import { backlogContext } from "../storage/backlog.js";
  */
 function buildStorageRootHeader(projectPath: string, workspacePath?: string): string {
   const ws = detectWorkspace(projectPath);
-  const isWorkspace = ws.type !== "single" || (workspacePath != null && workspacePath !== projectPath);
+  const hasGit = existsSync(join(projectPath, ".git"));
+  const isWorkspace = hasGit ? false : (ws.type !== "single" || (workspacePath != null && workspacePath !== projectPath));
   const sessionType = isWorkspace ? "workspace (multi-repo)" : "single-repo";
   const storageRoot = join(projectPath, AXME_CODE_DIR);
   const lines = [


### PR DESCRIPTION
## Summary
- When MCP server cwd has `.git/`, force `isWorkspace=false` — no parent workspace auto-detection
- Applies to `server.ts` (startup), `cli.ts` (setup command), `context.ts` (storage header)
- Ensures sessions, audit logs, hooks all write to repo `.axme-code/` instead of parent workspace
- Implements D-116

## Context
B-001 E2E test found that sessions/audit-logs/handoff were stored at workspace level even when the MCP server was launched from a repo directory. Root cause: `detectWorkspace()` would detect the parent workspace, switching to workspace mode. Now, presence of `.git/` forces repo mode.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 413 tests, 0 failures
- [ ] Run `axme-code setup` from repo dir → verify repo-level `.claude/settings.json` and `.mcp.json`
- [ ] Open new VS Code window from repo → verify sessions go to repo `.axme-code/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)