### PR TITLE
feat(telemetry): anonymous Phase 1 + Phase 2 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,34 @@ Additional presets available: `production-ready`, `team-collaboration`.
 
 ---
 
+## Telemetry
+
+axme-code sends anonymous usage telemetry to help us improve the product. We collect:
+
+- **Lifecycle events**: install, startup, version update
+- **Product health events**: setup completion, audit completion (counts of memories/decisions/safety extracted, duration, cost, error class)
+- **Errors**: category and bounded error class for failures in audit, setup, hooks, and auto-update
+
+What we **never** send:
+- Hostnames, usernames, file paths, working directories
+- Source code, transcripts, decisions, memories, or any project content
+- IP addresses (stripped at the server)
+- Raw exception messages (we map to a small set of error classes)
+
+Each install gets a random 64-character machine ID stored in `~/.local/share/axme-code/machine-id`. The ID is not derived from hardware and cannot be linked back to you.
+
+**To disable telemetry**, set either of these environment variables:
+
+```bash
+export AXME_TELEMETRY_DISABLED=1
+# or the industry-standard:
+export DO_NOT_TRACK=1
+```
+
+When disabled, no network requests are made and no machine ID is generated.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/TELEMETRY_TZ.md
+++ b/docs/TELEMETRY_TZ.md
@@ -1,0 +1,765 @@
+# axme-code Telemetry — Technical Specification
+
+**Status**: Backend ready. Client (this repo) needs implementation.
+**Endpoint**: `POST /v1/telemetry/events` on AXME gateway (prod: `https://api.cloud.axme.ai`)
+**Auth**: none (anonymous, public endpoint)
+**Created**: 2026-04-10 by control-plane PR #195
+
+## Why
+
+Platform admin dashboard tracks `axme-code` adoption (installs, DAU, version distribution, sources, activation rate). Without client-side telemetry events nothing is visible. The user-facing flow is anonymous — no `org_id`, no email, only an opaque random `mid` (machine ID).
+
+## Endpoint contract
+
+```
+POST https://api.cloud.axme.ai/v1/telemetry/events
+Content-Type: application/json
+
+{
+  "events": [
+    {
+      "event": "install" | "startup" | "update",
+      "version": "0.2.6",
+      "source": "binary" | "plugin",
+      "os": "linux" | "darwin" | "win32",
+      "arch": "x64" | "arm64",
+      "ci": false,
+      "mid": "<64 hex chars>",
+      "ts": "2026-04-10T12:00:00Z"
+    }
+    // up to 10 events per request (batch allowed for offline queue)
+  ]
+}
+```
+
+**Response** (always `200`, fire-and-forget):
+```json
+{ "ok": true }
+```
+
+The server **never** returns an error to the client — invalid events are silently dropped server-side. Client must NOT retry on non-2xx, NOT throw on network errors, NOT block any user-visible operation on the result of this call. It is purely best-effort.
+
+## Field semantics
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `event` | string | yes | One of: `install`, `startup`, `update` |
+| `version` | string | yes | semver, e.g. `0.2.6`. The same `__VERSION__` esbuild already injects |
+| `source` | string | yes | `binary` for install.sh / GitHub Releases binary, `plugin` for Claude Code plugin |
+| `os` | string | yes | `process.platform` Node value: `linux`, `darwin`, `win32` |
+| `arch` | string | yes | `process.arch` Node value: `x64`, `arm64` |
+| `ci` | boolean | no | `true` when running in CI (`process.env.CI === 'true'` or any `*_CI` envs); default `false` |
+| `mid` | string | yes | Anonymous machine ID (see below) |
+| `ts` | string | yes | ISO 8601 timestamp at the moment the event was generated client-side |
+
+### Machine ID (`mid`)
+
+- 64 hex chars (32 random bytes hex-encoded)
+- Generate **once** per install on first run, persist to disk
+- Storage location: `~/.local/share/axme-code/machine-id` (Linux/macOS), platform-equivalent on Windows
+- File mode `0600`
+- **Must NOT** be derived from hardware (no MAC address, no CPU serial, no hostname). Use `crypto.randomBytes(32).toString('hex')`
+- If file exists, read it. If not, generate and write
+- If file is corrupt or unreadable, regenerate (new mid). This is OK — analytics will treat it as a separate install which is the realistic behavior
+
+### Event triggers
+
+| Event | When to send |
+|---|---|
+| `install` | First time `axme-code` runs on this machine (mid file did not exist). Send immediately on first startup AFTER mid generation |
+| `startup` | Every time `axme-code serve` (MCP server) or `axme-code` CLI starts. Includes plugin start (Claude Code launches the plugin) |
+| `update` | When `axme-code` detects it has a different version than the previous run. Track previous version in same dir as mid (`~/.local/share/axme-code/last-version`) |
+
+**Important**: each unique `axme-code serve` process should send exactly one `startup` event at boot, not multiple. Don't send on every MCP request.
+
+### CI detection
+
+Skip events when in CI (avoid skewing DAU). Detect via:
+```ts
+const isCI = !!(
+  process.env.CI ||
+  process.env.GITHUB_ACTIONS ||
+  process.env.GITLAB_CI ||
+  process.env.CIRCLECI ||
+  process.env.BUILDKITE ||
+  process.env.JENKINS_URL
+);
+```
+
+If `isCI` is true, set `ci: true` in the event but **still send it** — the backend filter can use `ci=true` to exclude later. Don't drop events client-side, that loses information.
+
+## Implementation requirements
+
+### 1. Module placement
+
+Create `src/telemetry.ts` (next to other top-level src files like `auto-update.ts`). Single module owns:
+- mid generation/persistence
+- last-version tracking
+- event submission (fetch with timeout)
+- offline queue (JSONL file in same dir)
+
+### 2. Hot-path safety
+
+Telemetry **must not block** server startup or CLI command execution:
+- Use `setImmediate` or `void` to fire request asynchronously
+- Wrap entire telemetry call in try/catch — never throw
+- Network timeout 5 seconds max — don't wait longer than that
+- If fetch fails, queue to JSONL file and retry on next startup (max queue size: 100 events, drop oldest)
+
+### 3. Opt-out
+
+Respect environment variable `AXME_TELEMETRY_DISABLED=1`. When set, the entire telemetry module is a no-op (no network, no file writes, no mid generation). Document this in README.
+
+Also respect `DO_NOT_TRACK=1` (industry convention) — same behavior.
+
+### 4. Endpoint URL configurability
+
+Default endpoint: `https://api.cloud.axme.ai/v1/telemetry/events`
+
+Override via env var: `AXME_TELEMETRY_ENDPOINT=https://staging-...` (useful for testing against staging gateway).
+
+### 5. Privacy
+
+- **Never** send: hostname, username, working directory, file paths, environment variables, command-line args
+- **Never** log mid to console (it's anonymous but logging it makes it easy to leak)
+- The mid file is the ONLY persistent state created by telemetry
+- Document in README: "axme-code sends anonymous telemetry (install/startup/update events with random machine ID and version info). Disable with AXME_TELEMETRY_DISABLED=1."
+
+## Wiring points
+
+| File | Change |
+|---|---|
+| `src/server.ts` | Call `await sendTelemetry('startup', ...)` (non-blocking) right after MCP server starts listening. Also call `sendTelemetry('install', ...)` if mid was just generated, and `sendTelemetry('update', ...)` if version changed |
+| `src/cli.ts` | Same pattern for CLI subcommands (`setup`, `serve`, `status`) — but only on first invocation in a session (use a per-process flag to avoid double-sending if cli.ts spawns server) |
+| `src/telemetry.ts` | New file — implementation |
+| `README.md` | Add "Telemetry" section explaining what is sent, why, and how to disable |
+| `test/telemetry.test.ts` | New test file — verify mid generation, file persistence, CI detection, AXME_TELEMETRY_DISABLED opt-out, queue logic |
+
+## Testing
+
+```bash
+# Local testing against staging
+AXME_TELEMETRY_ENDPOINT=https://axme-gateway-staging-uc2bllq3la-uc.a.run.app/v1/telemetry/events \
+  node dist/server.js
+```
+
+Verify event lands in DB:
+```bash
+# (server-side, control-plane operator)
+# Query staging telemetry_events table via cloud-sql-proxy or admin endpoint:
+curl -H "x-api-key: $STG_KEY" \
+  https://axme-gateway-staging-uc2bllq3la-uc.a.run.app/admin/code/overview
+```
+
+Should show install/startup counts including your test events.
+
+## Verification checklist for the implementing agent
+
+- [ ] `src/telemetry.ts` created with mid generation, persistence, send, queue, opt-out
+- [ ] mid file at `~/.local/share/axme-code/machine-id` mode 0600, 64 hex chars
+- [ ] `install` event fires on first run only (mid file didn't exist)
+- [ ] `startup` event fires on every server/CLI start (once per process)
+- [ ] `update` event fires when version differs from `last-version` file
+- [ ] `AXME_TELEMETRY_DISABLED=1` and `DO_NOT_TRACK=1` fully disable telemetry (no network, no file writes)
+- [ ] Server startup is NOT blocked by telemetry — kill network and verify boot still works fast
+- [ ] Offline queue caps at 100 events
+- [ ] CI envs detected → `ci: true` in event
+- [ ] No PII, no paths, no hostname in any field
+- [ ] Tests cover: mid generation, opt-out, CI detection, queue, send error handling
+- [ ] README has Telemetry section
+- [ ] After local test against staging, verify event appears in `/admin/code/overview` (installs_total +1, dau +1)
+
+## Backend-side reference
+
+Endpoint code (already deployed to staging, will be in prod after PR #195 merges):
+- `services/gateway/misc_routes.py` — `POST /v1/telemetry/events` handler
+- `services/gateway/migrations/0057_telemetry_events.{postgresql,sqlite}.sql` — schema
+- `services/gateway/admin_routes.py` — `GET /admin/code/overview` aggregations
+
+Schema (PostgreSQL):
+```sql
+CREATE TABLE telemetry_events (
+    id          BIGSERIAL    PRIMARY KEY,
+    event       VARCHAR(20)  NOT NULL,
+    version     VARCHAR(20)  NOT NULL,
+    source      VARCHAR(20)  NOT NULL,
+    os          VARCHAR(20)  NOT NULL,
+    arch        VARCHAR(20)  NOT NULL,
+    ci          BOOLEAN      NOT NULL DEFAULT FALSE,
+    mid         VARCHAR(64)  NOT NULL,
+    ts          TIMESTAMPTZ  NOT NULL,
+    received_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+```
+
+Aggregations the backend computes:
+- `installs_total` — distinct mid where event=install
+- `installs_7d`, `installs_24h` — windowed
+- `dau`, `wau`, `mau` — distinct mid with startup in window
+- `activation_rate_pct` — % of installs that have ≥1 startup event after install
+- `versions` (top 20 last 7 days) — distinct mid per version
+- `sources` — distinct mid per source (binary vs plugin)
+- `install_growth_30d` — daily install counts last 30 days
+
+## Out of scope (do NOT implement)
+
+- Linking mid to AXME org_id (would break anonymity guarantee)
+- Sending command names, working dirs, or any path info
+- Sending count of MCP tool calls (separate concern, much later)
+- Geolocation / IP-based regions
+- Telemetry config UI in `axme-code setup` (just env var opt-out is enough for alpha)
+
+---
+
+# Phase 2 — Product health events
+
+**Status**: Specification only. Phase 1 (install/startup/update) must ship first.
+
+## Why a Phase 2
+
+Phase 1 answers "are users installing it?". It does **not** answer two questions that turned out to be critical during alpha:
+
+1. **"Is the session auditor actually saving anything?"** — On 2026-04-09 we discovered the auditor was producing 0 extractions on long transcripts because the LLM kept drifting from the output format. We only noticed because we manually inspected `.axme-code/audit-logs/` while debugging another issue. Five blind re-runs at $1+ each before we had any signal. With telemetry on `audit_complete` we would have seen the problem the day it shipped.
+
+2. **"Does setup actually complete for new users?"** — `axme-code setup` runs four LLM scanners in parallel. Any of them can fail (timeout, no API key, model error). When it falls back to the deterministic path, the user has a working install but is silently missing the LLM-extracted oracle. From `install` + `startup` events alone, this looks identical to a healthy install. We have no way to know the activation funnel is leaking until users complain.
+
+These two events plus a generic `error` channel unlock the failure-mode visibility we are missing. Phase 1 covers reach; Phase 2 covers product health.
+
+## New events
+
+### Event types
+
+| Event | When | Frequency per user |
+|---|---|---|
+| `audit_complete` | After `runSessionCleanup` finishes (success or LLM error) | ~1 per Claude Code session close |
+| `setup_complete` | After `axme-code setup` finishes (success or fallback) | Once per project init (rare) |
+| `error` | Caught error in audit / setup / hook / mcp_tool path | Variable, ideally rare |
+
+All three carry the same common fields as Phase 1 events (`event`, `version`, `source`, `os`, `arch`, `ci`, `mid`, `ts`) PLUS the event-specific fields below.
+
+### `audit_complete` payload
+
+```json
+{
+  "event": "audit_complete",
+  "version": "0.2.6",
+  "source": "binary",
+  "os": "linux",
+  "arch": "x64",
+  "ci": false,
+  "mid": "<64 hex chars>",
+  "ts": "2026-04-10T12:00:00Z",
+
+  "outcome": "success" | "failed" | "skipped",
+  "duration_ms": 415000,
+  "prompt_tokens": 134116,
+  "cost_usd": 1.58,
+  "chunks": 1,
+
+  "memories_saved": 2,
+  "decisions_saved": 0,
+  "safety_saved": 0,
+  "dropped_count": 0,
+
+  "error_class": null
+}
+```
+
+**Field semantics:**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `outcome` | string | yes | `success` (audit ran, parsed, saved), `failed` (LLM/parse/network error), `skipped` (ghost session, already audited, retry cap reached) |
+| `duration_ms` | int | yes | Wall-clock duration of the audit run from start to finish, including all LLM calls |
+| `prompt_tokens` | int | yes | Sum of analysis-phase prompt tokens across all chunks. 0 if skipped |
+| `cost_usd` | number | yes | Total LLM cost for this audit (analysis + format calls). 0 if skipped |
+| `chunks` | int | yes | Number of LLM call chunks (1 for short transcripts, >1 for split ones) |
+| `memories_saved` | int | yes | Number of memories actually written to storage (after dedup) |
+| `decisions_saved` | int | yes | Number of decisions actually written (after dedup) |
+| `safety_saved` | int | yes | Number of safety rules actually written (after dedup) |
+| `dropped_count` | int | yes | Number of extraction blocks the parser dropped due to missing required fields. **High value here = format drift, the bug we hit on 2026-04-09** |
+| `error_class` | string\|null | no | Set when `outcome=failed`. Short slug like `prompt_too_long`, `parse_error`, `network_error`, `timeout`, `api_error` |
+
+**No** raw text, slugs, titles, paths, or transcript content. Only counts and classes.
+
+### `setup_complete` payload
+
+```json
+{
+  "event": "setup_complete",
+  "version": "0.2.6",
+  "source": "binary",
+  "os": "linux",
+  "arch": "x64",
+  "ci": false,
+  "mid": "<64 hex chars>",
+  "ts": "2026-04-10T12:00:00Z",
+
+  "outcome": "success" | "fallback" | "failed",
+  "duration_ms": 45000,
+  "method": "llm" | "deterministic",
+  "scanners_run": 4,
+  "scanners_failed": 0,
+  "phase_failed": null,
+
+  "presets_applied": 2,
+  "is_workspace": false,
+  "child_repos": 0
+}
+```
+
+**Field semantics:**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `outcome` | string | yes | `success` (LLM init worked end-to-end), `fallback` (LLM init failed/skipped, deterministic fallback used and project IS usable), `failed` (everything failed, project unusable) |
+| `duration_ms` | int | yes | Wall-clock setup time |
+| `method` | string | yes | `llm` if any LLM scanner ran, `deterministic` if pure fallback |
+| `scanners_run` | int | yes | How many of the 4 scanners (oracle/decision/safety/deploy) actually executed |
+| `scanners_failed` | int | yes | How many of those returned an error |
+| `phase_failed` | string\|null | no | When `outcome=failed`, name of phase: `oracle_scan`, `decision_scan`, `safety_scan`, `deploy_scan`, `preset_apply`, `mcp_config_write`, `claude_md_write` |
+| `presets_applied` | int | yes | Count of preset bundles applied (0-4) |
+| `is_workspace` | bool | yes | True if the target was a workspace root (multi-repo) |
+| `child_repos` | int | yes | Number of child repos detected in the workspace (0 for single-repo) |
+
+### `error` payload
+
+```json
+{
+  "event": "error",
+  "version": "0.2.6",
+  "source": "binary",
+  "os": "linux",
+  "arch": "x64",
+  "ci": false,
+  "mid": "<64 hex chars>",
+  "ts": "2026-04-10T12:00:00Z",
+
+  "category": "audit" | "setup" | "hook" | "mcp_tool" | "auto_update",
+  "error_class": "string slug",
+  "fatal": false
+}
+```
+
+**Field semantics:**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `category` | string | yes | Subsystem where the error originated. One of: `audit`, `setup`, `hook`, `mcp_tool`, `auto_update` |
+| `error_class` | string | yes | Short slug, **not** a free-text message. Examples: `prompt_too_long`, `oauth_missing`, `api_rate_limit`, `transcript_not_found`, `parse_error`, `disk_full`, `permission_denied`, `network_error`, `unknown` |
+| `fatal` | bool | yes | True if the error caused the operation to abort entirely (vs degraded mode) |
+
+**Critical**: `error_class` must be a short, **bounded vocabulary** of slugs decided by the client code, not raw exception messages. Raw exception messages can leak file paths, usernames, or PII. The client maps caught exceptions to a known set of slugs (with `unknown` as the catch-all) before sending.
+
+## Backend changes required
+
+### Schema
+
+Two options:
+
+**Option A — single wide table (simpler):** Add nullable columns to `telemetry_events`:
+
+```sql
+ALTER TABLE telemetry_events ADD COLUMN outcome       VARCHAR(20);
+ALTER TABLE telemetry_events ADD COLUMN duration_ms   INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN cost_usd      NUMERIC(10,4);
+ALTER TABLE telemetry_events ADD COLUMN prompt_tokens INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN chunks        INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN memories_saved  INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN decisions_saved INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN safety_saved    INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN dropped_count   INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN method          VARCHAR(20);
+ALTER TABLE telemetry_events ADD COLUMN scanners_run    INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN scanners_failed INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN phase_failed    VARCHAR(40);
+ALTER TABLE telemetry_events ADD COLUMN presets_applied INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN is_workspace    BOOLEAN;
+ALTER TABLE telemetry_events ADD COLUMN child_repos     INTEGER;
+ALTER TABLE telemetry_events ADD COLUMN category        VARCHAR(20);
+ALTER TABLE telemetry_events ADD COLUMN error_class     VARCHAR(40);
+ALTER TABLE telemetry_events ADD COLUMN fatal           BOOLEAN;
+
+CREATE INDEX idx_telemetry_events_event_ts ON telemetry_events (event, ts DESC);
+CREATE INDEX idx_telemetry_events_outcome ON telemetry_events (outcome) WHERE outcome IS NOT NULL;
+CREATE INDEX idx_telemetry_events_error_class ON telemetry_events (category, error_class) WHERE error_class IS NOT NULL;
+```
+
+**Option B — JSONB blob (more flexible):** Add a single `payload JSONB` column for event-specific fields. Trade-off: easier to evolve, harder to query/index.
+
+Recommendation: **Option A** for alpha. Bounded set of fields, predictable queries, fast indexes. Switch to JSONB later if events keep multiplying.
+
+### Endpoint validation
+
+`POST /v1/telemetry/events` already accepts arbitrary fields per event. The backend handler must:
+
+1. Accept the new event types (`audit_complete`, `setup_complete`, `error`) without rejecting
+2. Map known optional fields into the new columns; unknown fields silently ignored
+3. Do NOT enforce required fields beyond what Phase 1 already requires (`event`, `version`, `source`, `os`, `arch`, `mid`, `ts`) — server-side rejection is bad for telemetry; clients can be on old versions
+
+### Aggregations / dashboard panels
+
+Add these aggregations alongside the existing Phase 1 ones in `GET /admin/code/overview`. Backend should compute and return them in the same response so dashboard can render in one call.
+
+#### Panel 1 — Audit health (the most important)
+
+```sql
+-- Audit success rate (last 7 days)
+SELECT
+  COUNT(*) FILTER (WHERE outcome = 'success')::float / NULLIF(COUNT(*), 0) AS success_rate,
+  COUNT(*) FILTER (WHERE outcome = 'failed')  AS failed_count,
+  COUNT(*) FILTER (WHERE outcome = 'success') AS success_count,
+  COUNT(*) FILTER (WHERE outcome = 'skipped') AS skipped_count
+FROM telemetry_events
+WHERE event = 'audit_complete' AND ts > NOW() - INTERVAL '7 days' AND ci = false;
+
+-- Average extractions per successful audit
+SELECT
+  AVG(memories_saved)  AS avg_memories,
+  AVG(decisions_saved) AS avg_decisions,
+  AVG(safety_saved)    AS avg_safety,
+  AVG(dropped_count)   AS avg_dropped
+FROM telemetry_events
+WHERE event = 'audit_complete' AND outcome = 'success'
+  AND ts > NOW() - INTERVAL '7 days' AND ci = false;
+
+-- % of audits with ZERO extractions (the silent failure mode)
+SELECT
+  COUNT(*) FILTER (WHERE memories_saved = 0 AND decisions_saved = 0 AND safety_saved = 0)::float
+  / NULLIF(COUNT(*), 0) AS zero_extraction_rate
+FROM telemetry_events
+WHERE event = 'audit_complete' AND outcome = 'success'
+  AND ts > NOW() - INTERVAL '7 days' AND ci = false;
+
+-- Top error classes
+SELECT error_class, COUNT(*) AS cnt
+FROM telemetry_events
+WHERE event = 'audit_complete' AND outcome = 'failed'
+  AND ts > NOW() - INTERVAL '7 days' AND ci = false
+GROUP BY error_class ORDER BY cnt DESC LIMIT 10;
+
+-- Cost distribution (need to know if anyone is burning $$)
+SELECT
+  PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY cost_usd) AS p50_cost,
+  PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY cost_usd) AS p95_cost,
+  MAX(cost_usd) AS max_cost,
+  SUM(cost_usd) AS total_cost
+FROM telemetry_events
+WHERE event = 'audit_complete' AND outcome = 'success'
+  AND ts > NOW() - INTERVAL '7 days' AND ci = false;
+
+-- Duration distribution
+SELECT
+  PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY duration_ms) AS p50_ms,
+  PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms) AS p95_ms
+FROM telemetry_events
+WHERE event = 'audit_complete' AND outcome = 'success'
+  AND ts > NOW() - INTERVAL '7 days' AND ci = false;
+```
+
+**Dashboard display for Audit health panel:**
+
+- **Big number cards**: Audit success rate %, zero-extraction rate %, total cost 7d
+- **Bar chart**: top error classes (last 7 days)
+- **Trend line**: avg memories+decisions+safety per audit, daily, last 30 days. **A drop here is the early warning sign.**
+- **Stacked bar**: outcomes per day (success / failed / skipped)
+- **Table**: cost p50/p95/max, duration p50/p95
+
+Why these specific cuts:
+- **Zero-extraction rate** is the metric that would have caught our 2026-04-09 bug instantly
+- **Top error classes** shows whether failures cluster (one fixable bug) or scatter (many small ones)
+- **Cost p95** tells us if some users have runaway audit costs
+
+#### Panel 2 — Setup health (activation funnel)
+
+```sql
+-- Setup outcome distribution (last 30 days)
+SELECT outcome, COUNT(DISTINCT mid) AS users
+FROM telemetry_events
+WHERE event = 'setup_complete' AND ts > NOW() - INTERVAL '30 days' AND ci = false
+GROUP BY outcome;
+
+-- Where setup fails most
+SELECT phase_failed, COUNT(*) AS cnt
+FROM telemetry_events
+WHERE event = 'setup_complete' AND outcome = 'failed' AND phase_failed IS NOT NULL
+  AND ts > NOW() - INTERVAL '30 days' AND ci = false
+GROUP BY phase_failed ORDER BY cnt DESC;
+
+-- LLM vs deterministic split
+SELECT method, COUNT(*) AS cnt
+FROM telemetry_events
+WHERE event = 'setup_complete' AND ts > NOW() - INTERVAL '30 days' AND ci = false
+GROUP BY method;
+
+-- Setup duration p50/p95
+SELECT
+  PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY duration_ms) AS p50_ms,
+  PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms) AS p95_ms
+FROM telemetry_events
+WHERE event = 'setup_complete' AND outcome IN ('success', 'fallback')
+  AND ts > NOW() - INTERVAL '30 days' AND ci = false;
+
+-- Setup-to-first-startup activation (Phase 1 already has activation_rate_pct
+-- but it counts install→startup. This is install→setup→startup which is more meaningful):
+WITH installed AS (
+  SELECT mid, MIN(ts) AS install_ts
+  FROM telemetry_events WHERE event = 'install' AND ci = false GROUP BY mid
+),
+setup_done AS (
+  SELECT mid FROM telemetry_events
+  WHERE event = 'setup_complete' AND outcome IN ('success', 'fallback') AND ci = false
+)
+SELECT
+  COUNT(*) FILTER (WHERE sd.mid IS NOT NULL)::float / NULLIF(COUNT(*), 0) AS setup_completion_rate
+FROM installed i LEFT JOIN setup_done sd ON i.mid = sd.mid
+WHERE i.install_ts > NOW() - INTERVAL '30 days';
+```
+
+**Dashboard display for Setup health panel:**
+
+- **Funnel chart**: install → setup_complete(success+fallback) → startup
+- **Pie chart**: outcome distribution (success / fallback / failed)
+- **Bar chart**: phase_failed counts when outcome=failed
+- **Big number**: % of installs that completed setup
+- **Big number**: LLM vs deterministic ratio (tells us how many users have ANTHROPIC_API_KEY / claude subscription configured)
+- **Histogram**: setup duration buckets (<10s, 10-30s, 30-60s, 60-120s, 120s+)
+
+Why:
+- **Funnel** shows where users drop off in onboarding. install but no setup = blocker before setup starts. setup but no startup = MCP integration broken.
+- **Phase failed bars** tells us which scanner crashes most. If it's always `oracle_scan`, we know where to fix.
+- **LLM ratio** is a rough proxy for "users with valid Claude credentials". Low ratio → most users hit fallback → they don't get the LLM benefits.
+
+#### Panel 3 — Errors
+
+```sql
+-- Errors by category (last 7 days)
+SELECT category, COUNT(*) AS cnt, COUNT(DISTINCT mid) AS users
+FROM telemetry_events
+WHERE event = 'error' AND ts > NOW() - INTERVAL '7 days' AND ci = false
+GROUP BY category ORDER BY cnt DESC;
+
+-- Top error classes overall
+SELECT category, error_class, COUNT(*) AS cnt, COUNT(DISTINCT mid) AS users
+FROM telemetry_events
+WHERE event = 'error' AND ts > NOW() - INTERVAL '7 days' AND ci = false
+GROUP BY category, error_class ORDER BY cnt DESC LIMIT 20;
+
+-- Fatal vs non-fatal split
+SELECT category, fatal, COUNT(*) AS cnt
+FROM telemetry_events
+WHERE event = 'error' AND ts > NOW() - INTERVAL '7 days' AND ci = false
+GROUP BY category, fatal;
+
+-- Error rate per active user (errors per DAU)
+WITH errors_7d AS (
+  SELECT COUNT(*) AS err_count FROM telemetry_events
+  WHERE event = 'error' AND ts > NOW() - INTERVAL '7 days' AND ci = false
+),
+dau_7d AS (
+  SELECT COUNT(DISTINCT mid) AS user_count FROM telemetry_events
+  WHERE event = 'startup' AND ts > NOW() - INTERVAL '7 days' AND ci = false
+)
+SELECT err_count::float / NULLIF(user_count, 0) AS errors_per_active_user
+FROM errors_7d, dau_7d;
+```
+
+**Dashboard display for Errors panel:**
+
+- **Stacked bar**: errors per day, stacked by category
+- **Table**: top 20 (category, error_class, count, distinct users)
+- **Big number**: errors per active user, this week
+- **Big number**: % of errors that are fatal
+
+### Suggested admin endpoint extensions
+
+`GET /admin/code/overview` should add a `phase2` block to the JSON response:
+
+```json
+{
+  "phase1": { /* existing install/startup/update aggregations */ },
+  "phase2": {
+    "audit": {
+      "success_rate_7d": 0.92,
+      "zero_extraction_rate_7d": 0.05,
+      "avg_memories_saved": 1.3,
+      "avg_decisions_saved": 0.4,
+      "avg_safety_saved": 0.1,
+      "avg_dropped_count": 0.0,
+      "total_cost_usd_7d": 12.50,
+      "p50_duration_ms": 180000,
+      "p95_duration_ms": 420000,
+      "p50_cost_usd": 0.45,
+      "p95_cost_usd": 1.80,
+      "outcomes_7d": [
+        { "date": "2026-04-04", "success": 12, "failed": 1, "skipped": 0 },
+        ...
+      ],
+      "top_error_classes": [
+        { "error_class": "prompt_too_long", "count": 3 },
+        { "error_class": "parse_error", "count": 1 }
+      ]
+    },
+    "setup": {
+      "completion_rate_30d": 0.87,
+      "outcomes_30d": { "success": 45, "fallback": 8, "failed": 4 },
+      "method_30d": { "llm": 50, "deterministic": 7 },
+      "phase_failed_30d": [
+        { "phase_failed": "oracle_scan", "count": 3 },
+        { "phase_failed": "preset_apply", "count": 1 }
+      ],
+      "p50_duration_ms": 35000,
+      "p95_duration_ms": 90000
+    },
+    "errors": {
+      "by_category_7d": [
+        { "category": "audit", "count": 5, "users": 2 },
+        { "category": "hook", "count": 2, "users": 2 }
+      ],
+      "top_classes_7d": [
+        { "category": "audit", "error_class": "prompt_too_long", "count": 3, "users": 1 },
+        ...
+      ],
+      "errors_per_active_user_7d": 0.18,
+      "fatal_pct_7d": 0.4
+    }
+  }
+}
+```
+
+The dashboard can render Phase 2 panels conditionally — if `phase2.audit.outcomes_7d` is empty (no clients have upgraded yet), hide the panel.
+
+## Client implementation plan (axme-code side)
+
+These are notes for the client implementation (in this repo), not the backend. Backend agent does NOT need to implement any of this.
+
+### `audit_complete` wiring
+
+In `src/session-cleanup.ts`, at the end of `runSessionCleanup`:
+
+```ts
+// After all writes are done, before return
+sendTelemetry("audit_complete", {
+  outcome: result.skipped ? "skipped" : audit ? "success" : "failed",
+  duration_ms: Date.now() - auditStartMs,
+  prompt_tokens: audit?.promptTokens ?? 0,
+  cost_usd: audit?.cost?.costUsd ?? 0,
+  chunks: audit?.chunks ?? 0,
+  memories_saved: result.memories,
+  decisions_saved: result.decisions,
+  safety_saved: result.safetyRules,
+  dropped_count: 0, // TODO: surface from parser
+  error_class: lastAuditError ? classifyError(lastAuditError) : null,
+});
+```
+
+The `dropped_count` requires the parser to return how many blocks it dropped. Add a counter to `parseAuditOutput` return value. Increment in every `process.stderr.write("AXME auditor: ... dropped ...")` site.
+
+### `setup_complete` wiring
+
+In `src/cli.ts`, after the `setup` subcommand completes (both success and failure paths):
+
+```ts
+sendTelemetry("setup_complete", {
+  outcome: result.errors.length > 0 && !result.created ? "failed" :
+           result.oracle.llm ? "success" : "fallback",
+  duration_ms: Date.now() - setupStartMs,
+  method: result.oracle.llm ? "llm" : "deterministic",
+  scanners_run: result.scannersRun ?? 0, // need to track this
+  scanners_failed: result.scannersFailed ?? 0,
+  phase_failed: result.errors[0]?.phase ?? null, // need to add phase to errors
+  presets_applied: result.presetsApplied ?? 0,
+  is_workspace: result.isWorkspace ?? false,
+  child_repos: result.childRepos ?? 0,
+});
+```
+
+The result type needs to grow a few fields to make this clean. That's a small refactor in `tools/init.ts`.
+
+### `error` wiring
+
+Helper:
+
+```ts
+// src/telemetry.ts
+export function reportError(category: string, errorClass: string, fatal: boolean) {
+  sendTelemetry("error", { category, error_class: errorClass, fatal });
+}
+
+// Bounded vocabulary of error classes
+export type ErrorClass =
+  | "prompt_too_long"
+  | "api_error"
+  | "api_rate_limit"
+  | "oauth_missing"
+  | "network_error"
+  | "timeout"
+  | "parse_error"
+  | "transcript_not_found"
+  | "permission_denied"
+  | "disk_full"
+  | "config_invalid"
+  | "unknown";
+
+export function classifyError(err: unknown): ErrorClass {
+  const msg = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+  if (msg.includes("prompt is too long") || msg.includes("max tokens")) return "prompt_too_long";
+  if (msg.includes("rate limit") || msg.includes("429")) return "api_rate_limit";
+  if (msg.includes("authentication") || msg.includes("api key")) return "oauth_missing";
+  if (msg.includes("timeout") || msg.includes("timed out")) return "timeout";
+  if (msg.includes("enoent") || msg.includes("transcript")) return "transcript_not_found";
+  if (msg.includes("eacces") || msg.includes("permission denied")) return "permission_denied";
+  if (msg.includes("enospc") || msg.includes("no space")) return "disk_full";
+  if (msg.includes("network") || msg.includes("econnrefused") || msg.includes("fetch failed")) return "network_error";
+  if (msg.includes("unexpected token") || msg.includes("invalid json") || msg.includes("parse")) return "parse_error";
+  return "unknown";
+}
+```
+
+The vocabulary is intentionally small. New error classes are added as we see `unknown` cluster around a specific cause in the dashboard.
+
+Call sites:
+- `src/agents/session-auditor.ts` — wrap LLM call in try/catch, report `audit` errors
+- `src/tools/init.ts` — wrap each scanner, report `setup` errors with phase
+- `src/hooks/*.ts` — caught errors get `hook` category (hooks are silent so this is the only signal)
+- `src/server.ts` — MCP tool handler exceptions get `mcp_tool` category
+
+### Privacy review of Phase 2 fields
+
+Re-checking each new field for PII:
+
+- All numeric counts: safe, no PII possible
+- `outcome` enum: safe
+- `phase_failed` enum: safe (bounded vocabulary)
+- `category` enum: safe
+- `error_class` slug: safe IF the client maps from caught exception to a bounded vocabulary slug. **The client must NEVER send the raw exception message.** This is the only privacy-sensitive guarantee in Phase 2.
+- `is_workspace` bool: safe
+- `child_repos` int: safe (just a count)
+- `method` enum: safe
+- `cost_usd` number: safe
+
+No new mid generation, no new persisted state beyond Phase 1.
+
+## Verification checklist (Phase 2, backend agent)
+
+- [ ] `telemetry_events` table extended with the columns from Option A above
+- [ ] Indexes added: `(event, ts)`, `(outcome) WHERE NOT NULL`, `(category, error_class) WHERE NOT NULL`
+- [ ] `POST /v1/telemetry/events` accepts the 3 new event types and writes new fields
+- [ ] `GET /admin/code/overview` returns `phase2` block with audit, setup, errors aggregations
+- [ ] Dashboard renders 3 new panels (Audit health, Setup health, Errors) — hidden if section is empty
+- [ ] Each panel matches the chart types listed above (big numbers, bars, funnel, table)
+- [ ] All aggregation queries filter `ci = false` (CI runs would skew product metrics)
+- [ ] `phase_failed`, `error_class`, `category`, `outcome`, `method` columns are indexed if you plan to filter by them in the dashboard
+- [ ] Backwards compatible: clients on 0.2.x that only send Phase 1 events still work; new columns are nullable
+
+## Out of scope (Phase 2)
+
+Same as Phase 1, plus:
+- Real-time alerts (we monitor by manually checking the dashboard for now)
+- Per-version regression tracking (compare audit success rate v0.2.6 vs v0.2.7) — useful but not for first iteration
+- Cost forecasting / budget alerts
+- Heatmap of when audits run (time-of-day)
+
+## Questions for control-plane team
+
+If anything in this spec is unclear or you discover edge cases during implementation, post in the AXME control-plane PR #195 thread or ping George.

--- a/src/agents/session-auditor.ts
+++ b/src/agents/session-auditor.ts
@@ -46,6 +46,8 @@ export interface SessionAuditResult {
   chunks?: number;
   /** Estimated prompt tokens for observability. */
   promptTokens?: number;
+  /** Number of extraction blocks the parser dropped due to missing required fields. Used for telemetry. */
+  droppedCount?: number;
 }
 
 /**
@@ -537,6 +539,7 @@ export async function runSessionAudit(opts: {
   let totalCostUsd = 0;
   let totalCostCached: CostInfo | undefined;
   let totalPromptChars = 0;
+  let totalDroppedCount = 0;
 
   for (let i = 0; i < chunks.length; i++) {
     const chunkBlock = chunks[i];
@@ -561,6 +564,7 @@ export async function runSessionAudit(opts: {
     });
 
     totalPromptChars += chunkResult.promptChars;
+    totalDroppedCount += chunkResult.droppedCount ?? 0;
     if (chunkResult.cost) {
       totalCostCached = chunkResult.cost;
       totalCostUsd += chunkResult.cost.costUsd ?? 0;
@@ -594,6 +598,7 @@ export async function runSessionAudit(opts: {
     durationMs: Date.now() - startTime,
     chunks: chunks.length,
     promptTokens: Math.round(totalPromptChars / 4),
+    droppedCount: totalDroppedCount,
   };
 }
 
@@ -639,7 +644,7 @@ async function runSingleAuditCall(opts: {
     // auto-loading the project's .claude/settings.json, but users or CI may
     // register hooks via environment or other means, so the belt-and-braces
     // env check in every hook handler is what actually stops the recursion.
-    env: { ...process.env, AXME_SKIP_HOOKS: "1" },
+    env: { ...process.env, AXME_SKIP_HOOKS: "1", AXME_TELEMETRY_DISABLED: "1" },
   };
 
   const isMultiChunk = opts.totalChunks > 1;
@@ -891,7 +896,7 @@ ${freeTextAnalysis}`;
       "Read", "Grep", "Glob", "Write", "Edit", "NotebookEdit", "Agent",
       "Skill", "TodoWrite", "WebFetch", "WebSearch", "Bash", "ToolSearch",
     ],
-    env: { ...process.env, AXME_SKIP_HOOKS: "1" },
+    env: { ...process.env, AXME_SKIP_HOOKS: "1", AXME_TELEMETRY_DISABLED: "1" },
   };
 
   const q = sdk.query({ prompt: formatPrompt, options: queryOpts });
@@ -925,10 +930,11 @@ ${freeTextAnalysis}`;
  */
 export function parseAuditOutput(output: string | object, sessionId: string): Omit<SessionAuditResult, "cost" | "durationMs"> {
   const today = new Date().toISOString().slice(0, 10);
+  let droppedCount = 0;
   const json = typeof output === "object" ? output : extractJson(output);
   if (!json) {
     process.stderr.write(`AXME auditor: failed to extract JSON from output (${typeof output === "string" ? output.length : 0} chars). First 300: ${typeof output === "string" ? output.slice(0, 300) : JSON.stringify(output).slice(0, 300)}\n`);
-    return { memories: [], decisions: [], safetyRules: [], oracleNeedsRescan: false, questions: [], handoff: null, sessionSummary: null };
+    return { memories: [], decisions: [], safetyRules: [], oracleNeedsRescan: false, questions: [], handoff: null, sessionSummary: null, droppedCount: 0 };
   }
 
   // Parse memories
@@ -945,11 +951,11 @@ export function parseAuditOutput(output: string | object, sessionId: string): Om
       const fieldName = m.body ? "body" : m.summary ? "summary" : "description";
       process.stderr.write(`AXME auditor: memory title recovered from ${fieldName}: ${title.slice(0, 80)}\n`);
     }
-    if (!title) { process.stderr.write(`AXME auditor: memory dropped (no usable content): ${JSON.stringify(m).slice(0, 200)}\n`); continue; }
+    if (!title) { droppedCount++; process.stderr.write(`AXME auditor: memory dropped (no usable content): ${JSON.stringify(m).slice(0, 200)}\n`); continue; }
     const type = m.type;
-    if (type !== "feedback" && type !== "pattern") { process.stderr.write(`AXME auditor: memory "${title.slice(0, 60)}" dropped (invalid type: ${type})\n`); continue; }
+    if (type !== "feedback" && type !== "pattern") { droppedCount++; process.stderr.write(`AXME auditor: memory "${title.slice(0, 60)}" dropped (invalid type: ${type})\n`); continue; }
     const slug = toMemorySlug(m.slug || title);
-    if (!slug) { process.stderr.write(`AXME auditor: memory "${title.slice(0, 60)}" dropped (could not generate slug)\n`); continue; }
+    if (!slug) { droppedCount++; process.stderr.write(`AXME auditor: memory "${title.slice(0, 60)}" dropped (could not generate slug)\n`); continue; }
     const scope = parseScopeField(m.scope);
     memories.push({
       slug, type, title,
@@ -965,10 +971,11 @@ export function parseAuditOutput(output: string | object, sessionId: string): Om
   const decisions: Omit<Decision, "id">[] = [];
   for (const d of (Array.isArray(json.decisions) ? json.decisions : [])) {
     const title = d.title;
-    if (!title) { process.stderr.write(`AXME auditor: decision dropped (no title): ${JSON.stringify(d).slice(0, 200)}\n`); continue; }
+    if (!title) { droppedCount++; process.stderr.write(`AXME auditor: decision dropped (no title): ${JSON.stringify(d).slice(0, 200)}\n`); continue; }
     // Fallback: if decision body is missing, try reasoning or use title
     let decision = d.decision || d.reasoning || "";
     if (!decision) {
+      droppedCount++;
       process.stderr.write(`AXME auditor: decision "${title}" dropped (no decision or reasoning field)\n`);
       continue;
     }
@@ -996,8 +1003,8 @@ export function parseAuditOutput(output: string | object, sessionId: string): Om
   for (const s of (Array.isArray(json.safety) ? json.safety : [])) {
     const ruleType = s.rule_type;
     const value = s.value;
-    if (!ruleType) { process.stderr.write(`AXME auditor: safety dropped (no rule_type): ${JSON.stringify(s).slice(0, 200)}\n`); continue; }
-    if (!value) { process.stderr.write(`AXME auditor: safety dropped (no value, rule_type=${ruleType})\n`); continue; }
+    if (!ruleType) { droppedCount++; process.stderr.write(`AXME auditor: safety dropped (no rule_type): ${JSON.stringify(s).slice(0, 200)}\n`); continue; }
+    if (!value) { droppedCount++; process.stderr.write(`AXME auditor: safety dropped (no value, rule_type=${ruleType})\n`); continue; }
     const scope = parseScopeField(s.scope);
     safetyRules.push({ ruleType, value, ...(scope ? { scope } : {}) });
   }
@@ -1046,7 +1053,7 @@ export function parseAuditOutput(output: string | object, sessionId: string): Om
   const sessionSummary = json.session_summary && typeof json.session_summary === "string" && json.session_summary.trim().length > 10
     ? json.session_summary.trim() : null;
 
-  return { memories, decisions, safetyRules, oracleNeedsRescan, questions, handoff, sessionSummary };
+  return { memories, decisions, safetyRules, oracleNeedsRescan, questions, handoff, sessionSummary, droppedCount };
 }
 
 /**

--- a/src/auto-update.ts
+++ b/src/auto-update.ts
@@ -217,7 +217,12 @@ export async function backgroundAutoUpdate(): Promise<void> {
         updated: false,
       });
     }
-  } catch {
-    // Never crash the server due to update logic
+  } catch (err) {
+    // Never crash the server due to update logic.
+    // Report to telemetry so we can see auto-update failures in aggregate.
+    try {
+      const { reportError, classifyError } = await import("./telemetry.js");
+      reportError("auto_update", classifyError(err), false);
+    } catch { /* swallow */ }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -266,8 +266,23 @@ After setup, run 'claude' as usual. AXME tools are available automatically.`);
 }
 
 async function main() {
+  // Send anonymous startup telemetry only for user-facing CLI commands.
+  // Hook and audit-session subcommands run as short-lived subprocesses
+  // (Claude Code hooks fire many times per session, audit-session is a
+  // detached background worker), so firing telemetry per invocation would
+  // spam the endpoint and skew startup counts. The `serve` command sends
+  // its own startup event from server.ts after MCP server is up.
+  // We AWAIT this so events flush before heavy work begins — under event
+  // loop pressure (LLM scanners), fire-and-forget setImmediate may stall.
+  const startupCommands = new Set(["setup", "status", "stats", "audit-kb", "cleanup", "help"]);
+  if (command && startupCommands.has(command)) {
+    const { sendStartupEvents } = await import("./telemetry.js");
+    await sendStartupEvents();
+  }
+
   switch (command) {
     case "setup": {
+      const setupStartMs = Date.now();
       const forceSetup = args.includes("--force");
       const pluginMode = args.includes("--plugin") || !!process.env.CLAUDE_PLUGIN_ROOT;
       const setupArgs = args.filter(a => a !== "--force" && a !== "--plugin");
@@ -275,6 +290,31 @@ async function main() {
       const hasGitDir = existsSync(join(projectPath, ".git"));
       const ws = detectWorkspace(projectPath);
       const isWorkspace = hasGitDir ? false : ws.type !== "single";
+      const childRepos = isWorkspace
+        ? ws.projects.filter(p => existsSync(join(projectPath, p.path, ".git"))).length
+        : 0;
+      // Telemetry-relevant fields, populated as setup progresses
+      let setupOutcome: "success" | "fallback" | "failed" = "failed";
+      let setupMethod: "llm" | "deterministic" = "deterministic";
+      let setupPhaseFailed: string | null = null;
+      let setupPresetsApplied = 0;
+      // Use the blocking variant so the event lands BEFORE process.exit() runs.
+      // The fire-and-forget sendTelemetry uses setImmediate, which is killed
+      // by process.exit() before the network request is even started.
+      const sendSetupTelemetry = async () => {
+        try {
+          const { sendTelemetryBlocking } = await import("./telemetry.js");
+          await sendTelemetryBlocking("setup_complete", {
+            outcome: setupOutcome,
+            duration_ms: Date.now() - setupStartMs,
+            method: setupMethod,
+            phase_failed: setupPhaseFailed,
+            presets_applied: setupPresetsApplied,
+            is_workspace: isWorkspace,
+            child_repos: childRepos,
+          });
+        } catch { /* swallow */ }
+      };
 
       if (isWorkspace) {
         console.log(`Initializing AXME Code workspace in ${projectPath} (${ws.type}, ${ws.projects.length} projects)...`);
@@ -289,36 +329,55 @@ async function main() {
         console.error(`To authenticate, run one of:`);
         console.error(`  claude login              (Claude subscription)`);
         console.error(`  export ANTHROPIC_API_KEY=sk-ant-...  (API key)\n`);
+        setupOutcome = "failed";
+        setupPhaseFailed = "auth_check";
+        await sendSetupTelemetry();
         process.exit(1);
       }
 
       // Init with LLM scanners (parallel)
-      if (isWorkspace) {
-        const { workspaceResult, projectResults } = await initWorkspaceWithLLM(projectPath, { onProgress: console.log });
-        const totalCost = workspaceResult.cost.costUsd + projectResults.reduce((s, r) => s + r.cost.costUsd, 0);
-        console.log(`  Workspace: ${workspaceResult.decisions.count} decisions, ${workspaceResult.memories.count} memories`);
-        for (const r of projectResults) {
-          const name = r.projectPath.split("/").pop();
-          console.log(`  ${name}: ${r.decisions.count} decisions (${r.decisions.fromScan} LLM + ${r.decisions.fromPresets} presets)`);
-        }
-        if (totalCost > 0) console.log(`  Total cost: $${totalCost.toFixed(2)}`);
-        for (const e of [...workspaceResult.errors, ...projectResults.flatMap(r => r.errors)]) {
-          console.log(`  Warning: ${e}`);
-        }
-        generateWorkspaceYaml(projectPath, ws);
-      } else {
-        const result = await initProjectWithLLM(projectPath, { onProgress: console.log, force: forceSetup });
-        if (!result.created && result.durationMs === 0) {
-          console.log(`  Already initialized (skipped LLM scan). Use --force to re-scan.`);
-          console.log(`  Decisions: ${result.decisions.count}, Memories: ${result.memories.count}`);
+      try {
+        if (isWorkspace) {
+          const { workspaceResult, projectResults } = await initWorkspaceWithLLM(projectPath, { onProgress: console.log });
+          const totalCost = workspaceResult.cost.costUsd + projectResults.reduce((s, r) => s + r.cost.costUsd, 0);
+          console.log(`  Workspace: ${workspaceResult.decisions.count} decisions, ${workspaceResult.memories.count} memories`);
+          for (const r of projectResults) {
+            const name = r.projectPath.split("/").pop();
+            console.log(`  ${name}: ${r.decisions.count} decisions (${r.decisions.fromScan} LLM + ${r.decisions.fromPresets} presets)`);
+          }
+          if (totalCost > 0) console.log(`  Total cost: $${totalCost.toFixed(2)}`);
+          for (const e of [...workspaceResult.errors, ...projectResults.flatMap(r => r.errors)]) {
+            console.log(`  Warning: ${e}`);
+          }
+          generateWorkspaceYaml(projectPath, ws);
+          // Track telemetry: any LLM scan in any repo means LLM method
+          const anyLlm = projectResults.some(r => r.oracle.llm) || workspaceResult.decisions.fromScan > 0;
+          setupMethod = anyLlm ? "llm" : "deterministic";
+          setupPresetsApplied = projectResults.reduce((s, r) => s + (r.decisions.fromPresets || 0), 0);
         } else {
-          console.log(`  Oracle: ${result.oracle.files} files (${result.oracle.llm ? "LLM scan" : "deterministic fallback"})`);
-          console.log(`  Decisions: ${result.decisions.count} (${result.decisions.fromScan} LLM + ${result.decisions.fromPresets} presets)`);
-          console.log(`  Memories: ${result.memories.count} (${result.memories.fromPresets} from presets)`);
-          console.log(`  Safety: ${result.safety.llm ? "LLM scan" : "defaults + presets"}`);
-          if (result.cost.costUsd > 0) console.log(`  Cost: $${result.cost.costUsd.toFixed(2)}, ${(result.durationMs / 1000).toFixed(1)}s`);
-          for (const e of result.errors) console.log(`  Warning: ${e}`);
+          const result = await initProjectWithLLM(projectPath, { onProgress: console.log, force: forceSetup });
+          if (!result.created && result.durationMs === 0) {
+            console.log(`  Already initialized (skipped LLM scan). Use --force to re-scan.`);
+            console.log(`  Decisions: ${result.decisions.count}, Memories: ${result.memories.count}`);
+          } else {
+            console.log(`  Oracle: ${result.oracle.files} files (${result.oracle.llm ? "LLM scan" : "deterministic fallback"})`);
+            console.log(`  Decisions: ${result.decisions.count} (${result.decisions.fromScan} LLM + ${result.decisions.fromPresets} presets)`);
+            console.log(`  Memories: ${result.memories.count} (${result.memories.fromPresets} from presets)`);
+            console.log(`  Safety: ${result.safety.llm ? "LLM scan" : "defaults + presets"}`);
+            if (result.cost.costUsd > 0) console.log(`  Cost: $${result.cost.costUsd.toFixed(2)}, ${(result.durationMs / 1000).toFixed(1)}s`);
+            for (const e of result.errors) console.log(`  Warning: ${e}`);
+          }
+          // Track telemetry: oracle.llm tells us whether LLM path was used
+          setupMethod = result.oracle.llm ? "llm" : "deterministic";
+          setupPresetsApplied = (result.decisions.fromPresets || 0);
         }
+      } catch (err) {
+        setupOutcome = "failed";
+        setupPhaseFailed = "init_scan";
+        const { classifyError, reportError } = await import("./telemetry.js");
+        try { reportError("setup", classifyError(err), true); } catch { /* swallow */ }
+        await sendSetupTelemetry();
+        throw err;
       }
 
       // Detect plugin context — skip .mcp.json and hooks if running from plugin
@@ -377,6 +436,11 @@ async function main() {
         ? ws.projects.filter(p => existsSync(join(projectPath, p.path, ".git"))).length
         : 0;
       writeBootstrapToAxmeMemory(projectPath, isWorkspace, repoCount);
+
+      // Setup completed. setupMethod was set above by the init scan.
+      // outcome=success when LLM ran end-to-end, fallback when deterministic was used.
+      setupOutcome = setupMethod === "llm" ? "success" : "fallback";
+      await sendSetupTelemetry();
 
       console.log("\nDone! Run 'claude' to start using AXME tools.");
       break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -298,6 +298,8 @@ async function main() {
       let setupMethod: "llm" | "deterministic" = "deterministic";
       let setupPhaseFailed: string | null = null;
       let setupPresetsApplied = 0;
+      let setupScannersRun = 0;
+      let setupScannersFailed = 0;
       // Use the blocking variant so the event lands BEFORE process.exit() runs.
       // The fire-and-forget sendTelemetry uses setImmediate, which is killed
       // by process.exit() before the network request is even started.
@@ -308,6 +310,8 @@ async function main() {
             outcome: setupOutcome,
             duration_ms: Date.now() - setupStartMs,
             method: setupMethod,
+            scanners_run: setupScannersRun,
+            scanners_failed: setupScannersFailed,
             phase_failed: setupPhaseFailed,
             presets_applied: setupPresetsApplied,
             is_workspace: isWorkspace,
@@ -354,6 +358,9 @@ async function main() {
           const anyLlm = projectResults.some(r => r.oracle.llm) || workspaceResult.decisions.fromScan > 0;
           setupMethod = anyLlm ? "llm" : "deterministic";
           setupPresetsApplied = projectResults.reduce((s, r) => s + (r.decisions.fromPresets || 0), 0);
+          // Sum scanner counts across workspace + all projects
+          setupScannersRun = workspaceResult.scannersRun + projectResults.reduce((s, r) => s + r.scannersRun, 0);
+          setupScannersFailed = workspaceResult.scannersFailed + projectResults.reduce((s, r) => s + r.scannersFailed, 0);
         } else {
           const result = await initProjectWithLLM(projectPath, { onProgress: console.log, force: forceSetup });
           if (!result.created && result.durationMs === 0) {
@@ -370,6 +377,8 @@ async function main() {
           // Track telemetry: oracle.llm tells us whether LLM path was used
           setupMethod = result.oracle.llm ? "llm" : "deterministic";
           setupPresetsApplied = (result.decisions.fromPresets || 0);
+          setupScannersRun = result.scannersRun;
+          setupScannersFailed = result.scannersFailed;
         }
       } catch (err) {
         setupOutcome = "failed";

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -68,7 +68,13 @@ export async function runPostToolUseHook(workspacePath?: string): Promise<void> 
     for await (const chunk of process.stdin) chunks.push(chunk);
     const input = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as HookInput;
     handlePostToolUse(workspacePath, input);
-  } catch {
-    // Hook failures must be silent
+  } catch (err) {
+    // Hook failures must be silent — but reported to telemetry for visibility.
+    // Use blocking send: hook subprocess exits ms after this catch and would
+    // kill any setImmediate-queued network call.
+    try {
+      const { sendTelemetryBlocking, classifyError } = await import("../telemetry.js");
+      await sendTelemetryBlocking("error", { category: "hook", error_class: classifyError(err), fatal: false });
+    } catch { /* swallow */ }
   }
 }

--- a/src/hooks/pre-tool-use.ts
+++ b/src/hooks/pre-tool-use.ts
@@ -219,7 +219,13 @@ export async function runPreToolUseHook(workspacePath?: string): Promise<void> {
     for await (const chunk of process.stdin) chunks.push(chunk);
     const input = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as HookInput;
     handlePreToolUse(workspacePath, input);
-  } catch {
-    // Hook failures must be silent - fail open for safety
+  } catch (err) {
+    // Hook failures must be silent - fail open for safety.
+    // Reported to telemetry via blocking send so the network call lands
+    // before this short-lived hook subprocess exits.
+    try {
+      const { sendTelemetryBlocking, classifyError } = await import("../telemetry.js");
+      await sendTelemetryBlocking("error", { category: "hook", error_class: classifyError(err), fatal: false });
+    } catch { /* swallow */ }
   }
 }

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -87,7 +87,12 @@ export async function runSessionEndHook(workspacePath?: string): Promise<void> {
       // Empty/invalid stdin is fine — we'll proceed without transcript attachment
     }
     handleSessionEnd(workspacePath, input);
-  } catch {
-    // Hook failures must be silent
+  } catch (err) {
+    // Hook failures must be silent — but reported to telemetry for visibility.
+    // Use blocking send: hook subprocess exits ms after this catch.
+    try {
+      const { sendTelemetryBlocking, classifyError } = await import("../telemetry.js");
+      await sendTelemetryBlocking("error", { category: "hook", error_class: classifyError(err), fatal: false });
+    } catch { /* swallow */ }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,6 +75,12 @@ clearLegacyPendingAuditsDir(defaultProjectPath);
 import { backgroundAutoUpdate, getUpdateNotification } from "./auto-update.js";
 backgroundAutoUpdate().catch(() => {});
 
+// Send anonymous startup telemetry (install/startup/update) — never throws.
+// We do not await here because server.ts is a top-level module side-effect;
+// the event loop has plenty of time during MCP server lifetime to flush.
+import { sendStartupEvents } from "./telemetry.js";
+void sendStartupEvents();
+
 
 /**
  * Return the AXME session UUID owned by this MCP server for worklog purposes.
@@ -431,8 +437,8 @@ server.tool(
     value: z.string().describe("Rule value (branch name, command prefix, or file path pattern)"),
   },
   async ({ project_path, rule_type, value }) => {
-
-    const result = updateSafetyTool(pp(project_path), rule_type, value);
+    const sid = getOwnedSessionIdForLogging();
+    const result = updateSafetyTool(pp(project_path), rule_type, value, sid ?? undefined);
     return { content: [{ type: "text" as const, text: `Safety rule added: ${result.ruleType} = ${result.value}` }] };
   },
 );
@@ -820,7 +826,7 @@ server.tool(
       for (const s of args.safety_rules) {
         try {
           if (s.action === "add") {
-            updateSafetyTool(targetPath, s.rule_type, s.value);
+            updateSafetyTool(targetPath, s.rule_type, s.value, sid);
             report.push(`Safety added: ${s.rule_type} = ${s.value}`);
           } else if (s.action === "remove") {
             const { removeSafetyRule } = await import("./storage/safety.js");
@@ -860,13 +866,36 @@ server.tool(
       appendFileSync(join(targetPath, AXME_CODE_DIR, "worklog.md"), worklogEntry);
     } catch {}
 
-    // 4. Set agentClosed flag
+    // 4. Set agentClosed flag and spawn detached auditor.
+    // The auditor runs in verify-only mode (since agentClosed=true) — its job
+    // is to catch anything the agent missed. Spawning here ensures the audit
+    // runs immediately on close, instead of waiting for SessionEnd hook (which
+    // may never fire if Claude Code is killed) or MCP server cleanup (which
+    // happens only when the server itself exits).
+    //
+    // IMPORTANT: we do NOT pre-set auditStatus=pending here. runSessionCleanup
+    // in the worker will claim the audit itself (setting pending + started_at
+    // atomically before the LLM call). If we set pending here, the worker
+    // would see its OWN pending state and self-dedup as "concurrent-audit",
+    // never actually running. The spawn→worker-read window is small (~1s)
+    // and no other code path spawns auditors for a session whose MCP server
+    // is still alive, so this gap is safe.
     const { loadSession, writeSession } = await import("./storage/sessions.js");
     const session = loadSession(targetPath, sid);
     if (session) {
       session.agentClosed = true;
       session.closedAt = new Date().toISOString();
       writeSession(targetPath, session);
+    }
+    // Spawn the detached audit worker. Best-effort — failure is logged but
+    // does not block the close response. If spawn fails, the next MCP server
+    // start will pick this up via the orphan-recovery path.
+    let auditorSpawned = false;
+    try {
+      spawnDetachedAuditWorker(targetPath, sid);
+      auditorSpawned = true;
+    } catch (err) {
+      process.stderr.write(`AXME finalize_close: failed to spawn auditor for ${sid}: ${err}\n`);
     }
 
     // 5. Build storage summary
@@ -878,6 +907,7 @@ server.tool(
       `- Handoff: written to .axme-code/plans/handoff.md`,
       `- Worklog: entry appended to .axme-code/worklog.md`,
       `- agentClosed: true`,
+      `- Auditor: ${auditorSpawned ? "spawned (verify-only mode, runs in background)" : "spawn failed - will run on next session start"}`,
       "",
       "Output to the user: first the storage summary above, then the startup_text below, then the feedback request.",
       "",

--- a/src/server.ts
+++ b/src/server.ts
@@ -232,6 +232,35 @@ const server = new McpServer(
   { instructions: buildInstructions() },
 );
 
+// Wrap every tool handler with a try/catch that reports caught exceptions to
+// telemetry under the `mcp_tool` category. We monkey-patch server.tool() once
+// here instead of touching all 19 individual tool registrations below. The
+// MCP SDK still receives any thrown error and returns it to the client, so
+// no behavior changes — we only add an extra observability hook.
+//
+// Why fatal=true: an exception that bubbles out of a tool handler means the
+// tool call did not complete its intended work — the user-visible operation
+// has aborted. That matches our "fatal vs degraded" definition.
+const _origRegisterTool: any = server.tool.bind(server);
+(server as any).tool = function (...args: any[]): any {
+  // Last argument is always the handler function
+  const handler = args[args.length - 1];
+  if (typeof handler === "function") {
+    args[args.length - 1] = async (...handlerArgs: any[]): Promise<any> => {
+      try {
+        return await handler(...handlerArgs);
+      } catch (err) {
+        try {
+          const { reportError, classifyError } = await import("./telemetry.js");
+          reportError("mcp_tool", classifyError(err), true);
+        } catch { /* never throw from telemetry */ }
+        throw err;
+      }
+    };
+  }
+  return _origRegisterTool.apply(server, args);
+};
+
 // --- Helper: resolve paths with defaults from server state ---
 
 function pp(project_path?: string): string {

--- a/src/session-cleanup.ts
+++ b/src/session-cleanup.ts
@@ -344,6 +344,12 @@ export async function runSessionCleanup(
 
   const result: SessionCleanupResult = { ...base };
   let auditSucceeded = false;
+  // Telemetry-relevant fields, populated inside the audit block, read after.
+  let auditStartMs = 0;
+  let auditPromptTokens = 0;
+  let auditChunks = 0;
+  let auditDroppedCount = 0;
+  let auditErrorClass: string | null = null;
   const activityLength = sessionTurns
     ? sessionTurns.reduce((s, t) => s + t.content.length, 0)
     : (sessionEvents ?? "").length;
@@ -365,7 +371,7 @@ export async function runSessionCleanup(
   // Run LLM audit only if there's meaningful activity to analyze
   if (hasActivity) {
     const auditStartIso = new Date().toISOString();
-    const auditStartMs = Date.now();
+    auditStartMs = Date.now();
 
     // Claim the audit for this process by setting auditStatus=pending in a
     // single writeSession call. This is not an atomic lock — two processes
@@ -654,6 +660,9 @@ export async function runSessionCleanup(
       result.decisions = audit.decisions.length;
       result.safetyRules = audit.safetyRules.length;
       result.costUsd = audit.cost?.costUsd ?? 0;
+      auditPromptTokens = audit.promptTokens ?? 0;
+      auditChunks = audit.chunks ?? 0;
+      auditDroppedCount = audit.droppedCount ?? 0;
       auditSucceeded = true;
 
       // Bump KB audit counter — after N session audits, recommend deep KB cleanup
@@ -737,6 +746,10 @@ export async function runSessionCleanup(
       // cap (MAX_AUDIT_ATTEMPTS) prevents infinite re-runs. recordAuditFailure
       // sets auditStatus=failed + auditFinishedAt + lastAuditError on the meta.
       recordAuditFailure(workspacePath, sessionId, err, "runSessionAudit");
+      try {
+        const { classifyError } = await import("./telemetry.js");
+        auditErrorClass = classifyError(err);
+      } catch { /* swallow */ }
       if (auditLogPath) {
         updateAuditLog(auditLogPath, {
           phase: "failed",
@@ -791,6 +804,32 @@ export async function runSessionCleanup(
         durationMs: 0, // duration is in audit-logs, not needed here
       });
     } catch {}
+  }
+
+  // Send anonymous telemetry: one audit_complete event per cleanup that
+  // actually attempted an audit (hasActivity=true). Skipped sessions (ghost,
+  // already-audited, concurrent, etc.) return earlier and never reach here.
+  // Use the blocking variant: runSessionCleanup is called from the detached
+  // audit-session subprocess which exits immediately after returning. The
+  // fire-and-forget setImmediate would be killed before the network request
+  // completes, dropping the event.
+  if (hasActivity) {
+    try {
+      const { sendTelemetryBlocking } = await import("./telemetry.js");
+      const outcome = result.auditRan ? "success" : "failed";
+      await sendTelemetryBlocking("audit_complete", {
+        outcome,
+        duration_ms: auditStartMs > 0 ? Date.now() - auditStartMs : 0,
+        prompt_tokens: auditPromptTokens,
+        cost_usd: result.costUsd,
+        chunks: auditChunks,
+        memories_saved: result.memories,
+        decisions_saved: result.decisions,
+        safety_saved: result.safetyRules,
+        dropped_count: auditDroppedCount,
+        error_class: auditErrorClass,
+      });
+    } catch { /* never throw from telemetry */ }
   }
 
   // Note: clearing the per-Claude-session mapping file is the caller's

--- a/src/storage/worklog.ts
+++ b/src/storage/worklog.ts
@@ -130,6 +130,15 @@ export function logMemorySaved(
   logEvent(projectPath, "memory_saved", sessionId, { slug, type });
 }
 
+export function logSafetyUpdated(
+  projectPath: string,
+  sessionId: string,
+  ruleType: string,
+  value: string,
+): void {
+  logEvent(projectPath, "safety_updated", sessionId, { ruleType, value });
+}
+
 export function logError(projectPath: string, sessionId: string, error: string): void {
   logEvent(projectPath, "error", sessionId, { error });
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,451 @@
+/**
+ * Anonymous telemetry for axme-code.
+ *
+ * Sends Phase 1 events (install, startup, update) and Phase 2 product-health
+ * events (audit_complete, setup_complete, error) to the AXME control plane.
+ *
+ * - Anonymous: only a random machine id (mid). No PII, no paths, no hostnames.
+ * - Best-effort: never blocks user-visible operations, never throws.
+ * - Opt-out: AXME_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1 fully disables.
+ *
+ * See docs/TELEMETRY_TZ.md for the full specification.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  appendFileSync,
+  unlinkSync,
+  chmodSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { AXME_CODE_VERSION } from "./types.js";
+
+// --- Configuration ---
+
+const DEFAULT_ENDPOINT = "https://api.cloud.axme.ai/v1/telemetry/events";
+const QUEUE_MAX_EVENTS = 100;
+// Per-request network timeout. Long enough that a heavily-busy event loop
+// (parallel LLM scanners) does not falsely flag successful POSTs as failed
+// — false-fail caused server-side duplicates because the failed event got
+// appended to the offline queue and re-sent on the next call.
+const SEND_TIMEOUT_MS = 30_000;
+
+/**
+ * Resolved state directory for telemetry files. AXME_TELEMETRY_getStateDir() env
+ * var overrides the default (used in tests). Read each call to support
+ * test isolation.
+ */
+function getStateDir(): string {
+  return process.env.AXME_TELEMETRY_STATE_DIR || join(homedir(), ".local", "share", "axme-code");
+}
+
+function getMidFile(): string { return join(getStateDir(), "machine-id"); }
+function getLastVersionFile(): string { return join(getStateDir(), "last-version"); }
+function getQueueFile(): string { return join(getStateDir(), "telemetry-queue.jsonl"); }
+
+// --- Types ---
+
+export type TelemetryEventType =
+  | "install"
+  | "startup"
+  | "update"
+  | "audit_complete"
+  | "setup_complete"
+  | "error";
+
+export interface TelemetryCommonFields {
+  event: TelemetryEventType;
+  version: string;
+  source: "binary" | "plugin";
+  os: string;
+  arch: string;
+  ci: boolean;
+  mid: string;
+  ts: string;
+}
+
+export type TelemetryEvent = TelemetryCommonFields & Record<string, unknown>;
+
+/** Bounded vocabulary of error classes. Add new entries only when seen in the wild. */
+export type ErrorClass =
+  | "prompt_too_long"
+  | "api_error"
+  | "api_rate_limit"
+  | "oauth_missing"
+  | "network_error"
+  | "timeout"
+  | "parse_error"
+  | "transcript_not_found"
+  | "permission_denied"
+  | "disk_full"
+  | "config_invalid"
+  | "unknown";
+
+// --- Process state ---
+
+let cachedMid: string | null = null;
+let processStartupSent = false;
+let cachedSource: "binary" | "plugin" | null = null;
+
+// --- Opt-out ---
+
+export function isTelemetryDisabled(): boolean {
+  return !!(process.env.AXME_TELEMETRY_DISABLED || process.env.DO_NOT_TRACK);
+}
+
+// --- Source detection ---
+
+/**
+ * Detect whether axme-code is running as a Claude Code plugin or standalone binary.
+ * Plugin context sets CLAUDE_PLUGIN_ROOT env var.
+ */
+export function detectSource(): "binary" | "plugin" {
+  if (cachedSource) return cachedSource;
+  cachedSource = process.env.CLAUDE_PLUGIN_ROOT ? "plugin" : "binary";
+  return cachedSource;
+}
+
+// --- CI detection ---
+
+export function isCI(): boolean {
+  return !!(
+    process.env.CI ||
+    process.env.GITHUB_ACTIONS ||
+    process.env.GITLAB_CI ||
+    process.env.CIRCLECI ||
+    process.env.BUILDKITE ||
+    process.env.JENKINS_URL
+  );
+}
+
+// --- Machine ID ---
+
+/**
+ * Read or generate the anonymous machine id.
+ * - 64 hex chars (32 random bytes)
+ * - Not derived from hardware
+ * - Persisted at ~/.local/share/axme-code/machine-id with mode 0600
+ * - On corrupted/unreadable file: regenerate (treated as new install)
+ *
+ * Returns { mid, isNew: true } when a fresh mid was generated.
+ *
+ * NOTE: When telemetry is disabled, this still generates an in-memory mid
+ * but does NOT persist it to disk. This way callers (sendStartupEvents,
+ * sendTelemetry) get a placeholder value but the user's machine state is
+ * not modified by an opt-out installation.
+ */
+export function getOrCreateMid(): { mid: string; isNew: boolean } {
+  if (cachedMid) return { mid: cachedMid, isNew: false };
+
+  const disabled = isTelemetryDisabled();
+
+  // Try to read existing mid
+  if (existsSync(getMidFile())) {
+    try {
+      const raw = readFileSync(getMidFile(), "utf-8").trim();
+      if (/^[0-9a-f]{64}$/.test(raw)) {
+        cachedMid = raw;
+        return { mid: raw, isNew: false };
+      }
+    } catch {
+      // fall through to regenerate
+    }
+  }
+
+  // Generate new mid
+  const newMid = randomBytes(32).toString("hex");
+  if (!disabled) {
+    try {
+      mkdirSync(getStateDir(), { recursive: true });
+      writeFileSync(getMidFile(), newMid, "utf-8");
+      try { chmodSync(getMidFile(), 0o600); } catch { /* non-fatal */ }
+    } catch {
+      // If we cannot persist, still return the in-memory mid for this process
+    }
+  }
+  cachedMid = newMid;
+  return { mid: newMid, isNew: true };
+}
+
+// --- Version tracking (for update detection) ---
+
+export function readLastVersion(): string | null {
+  try {
+    if (!existsSync(getLastVersionFile())) return null;
+    return readFileSync(getLastVersionFile(), "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastVersion(version: string): void {
+  try {
+    mkdirSync(getStateDir(), { recursive: true });
+    writeFileSync(getLastVersionFile(), version, "utf-8");
+  } catch {
+    // non-fatal
+  }
+}
+
+// --- Common fields builder ---
+
+function buildCommonFields(event: TelemetryEventType, mid: string): TelemetryCommonFields {
+  return {
+    event,
+    version: AXME_CODE_VERSION,
+    source: detectSource(),
+    os: process.platform,
+    arch: process.arch,
+    ci: isCI(),
+    mid,
+    ts: new Date().toISOString(),
+  };
+}
+
+// --- Send (with offline queue fallback) ---
+
+function getEndpoint(): string {
+  return process.env.AXME_TELEMETRY_ENDPOINT || DEFAULT_ENDPOINT;
+}
+
+async function postEvents(events: TelemetryEvent[]): Promise<boolean> {
+  const endpoint = getEndpoint();
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
+    const resp = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
+function readQueue(): TelemetryEvent[] {
+  try {
+    if (!existsSync(getQueueFile())) return [];
+    const raw = readFileSync(getQueueFile(), "utf-8");
+    const lines = raw.split("\n").filter(l => l.trim());
+    const out: TelemetryEvent[] = [];
+    for (const line of lines) {
+      try { out.push(JSON.parse(line)); } catch { /* skip corrupt line */ }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+function writeQueue(events: TelemetryEvent[]): void {
+  try {
+    mkdirSync(getStateDir(), { recursive: true });
+    // Cap at QUEUE_MAX_EVENTS, drop oldest
+    const capped = events.slice(-QUEUE_MAX_EVENTS);
+    writeFileSync(getQueueFile(), capped.map(e => JSON.stringify(e)).join("\n") + "\n", "utf-8");
+  } catch {
+    // non-fatal
+  }
+}
+
+function appendToQueue(event: TelemetryEvent): void {
+  try {
+    mkdirSync(getStateDir(), { recursive: true });
+    // Check current size — if over cap, rewrite trimmed
+    if (existsSync(getQueueFile())) {
+      const existing = readQueue();
+      if (existing.length >= QUEUE_MAX_EVENTS) {
+        existing.push(event);
+        writeQueue(existing);
+        return;
+      }
+    }
+    appendFileSync(getQueueFile(), JSON.stringify(event) + "\n", "utf-8");
+  } catch {
+    // non-fatal
+  }
+}
+
+function clearQueue(): void {
+  try { unlinkSync(getQueueFile()); } catch { /* non-fatal */ }
+}
+
+/**
+ * Send a single telemetry event. Best-effort, fire-and-forget.
+ *
+ * Behavior:
+ * - If telemetry disabled: no-op
+ * - On send success: also flushes any queued events
+ * - On send failure: appends to offline queue (capped at 100)
+ *
+ * Never throws, never blocks. Wraps everything in try/catch.
+ */
+export function sendTelemetry(
+  event: TelemetryEventType,
+  payload: Record<string, unknown> = {},
+): void {
+  if (isTelemetryDisabled()) return;
+  // Run async, do not await
+  setImmediate(() => {
+    void sendTelemetryAsync(event, payload).catch(() => { /* swallow */ });
+  });
+}
+
+/**
+ * Send a telemetry event and AWAIT completion. Use this only on critical
+ * exit paths (process.exit) where the fire-and-forget setImmediate from
+ * sendTelemetry() would be killed before the network request lands.
+ *
+ * Same best-effort guarantees: never throws, falls back to offline queue
+ * on failure. Returns when the send (or queue write) finishes.
+ */
+export async function sendTelemetryBlocking(
+  event: TelemetryEventType,
+  payload: Record<string, unknown> = {},
+): Promise<void> {
+  if (isTelemetryDisabled()) return;
+  try {
+    await sendTelemetryAsync(event, payload);
+  } catch { /* swallow */ }
+}
+
+async function sendTelemetryAsync(
+  event: TelemetryEventType,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const { mid } = getOrCreateMid();
+    const common = buildCommonFields(event, mid);
+    const fullEvent: TelemetryEvent = { ...common, ...payload };
+
+    // Try to send queued events along with the new one
+    const queued = readQueue();
+    const batch = [...queued, fullEvent].slice(-10); // batch limit per spec
+    const ok = await postEvents(batch);
+
+    if (ok) {
+      // Success: clear queue if we shipped queued events
+      if (queued.length > 0) clearQueue();
+    } else {
+      // Failure: queue this event for retry on next startup
+      appendToQueue(fullEvent);
+    }
+  } catch {
+    // swallow
+  }
+}
+
+// --- Lifecycle helpers ---
+
+/**
+ * Send the install/startup/update events that happen at process startup.
+ * Idempotent within a process: subsequent calls do nothing.
+ *
+ * Logic:
+ * 1. If mid did not exist before this call → send `install`
+ * 2. If last-version exists and differs from current → send `update`
+ * 3. Always send `startup` (once per process)
+ * 4. Update last-version file to current
+ *
+ * Awaitable. Callers should `await` it to ensure events are flushed before
+ * heavy work begins. Under event-loop pressure (e.g. parallel LLM scanners),
+ * fire-and-forget setImmediate callbacks may stall, causing fetch timeouts
+ * that flag successful POSTs as failed and append them to the offline queue.
+ * The next telemetry call then re-sends the queued events, producing
+ * server-side duplicates. Awaiting startup sends sequentially avoids this.
+ *
+ * Failures during the network call are still swallowed silently — the
+ * function never throws.
+ */
+export async function sendStartupEvents(): Promise<void> {
+  if (isTelemetryDisabled()) return;
+  if (processStartupSent) return;
+  processStartupSent = true;
+
+  try {
+    const { isNew } = getOrCreateMid();
+    const lastVersion = readLastVersion();
+    const currentVersion = AXME_CODE_VERSION;
+
+    if (isNew) {
+      await sendTelemetryBlocking("install");
+    }
+
+    if (lastVersion && lastVersion !== currentVersion) {
+      await sendTelemetryBlocking("update", { previous_version: lastVersion });
+    }
+
+    await sendTelemetryBlocking("startup");
+
+    if (lastVersion !== currentVersion) {
+      writeLastVersion(currentVersion);
+    }
+  } catch {
+    // swallow
+  }
+}
+
+// --- Phase 2: error helpers ---
+
+/**
+ * Map a caught exception to a bounded ErrorClass slug.
+ * Never sends raw exception messages to telemetry — only the slug.
+ */
+export function classifyError(err: unknown): ErrorClass {
+  const msg = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+  if (msg.includes("prompt is too long") || msg.includes("max tokens") || msg.includes("context length")) return "prompt_too_long";
+  if (msg.includes("rate limit") || msg.includes("429")) return "api_rate_limit";
+  if (msg.includes("authentication") || msg.includes("api key") || msg.includes("apikey") || msg.includes("authtoken")) return "oauth_missing";
+  if (msg.includes("timeout") || msg.includes("timed out") || msg.includes("aborted")) return "timeout";
+  if (msg.includes("enoent") || msg.includes("transcript not found")) return "transcript_not_found";
+  if (msg.includes("eacces") || msg.includes("permission denied")) return "permission_denied";
+  if (msg.includes("enospc") || msg.includes("no space")) return "disk_full";
+  if (msg.includes("network") || msg.includes("econnrefused") || msg.includes("fetch failed") || msg.includes("dns")) return "network_error";
+  if (msg.includes("unexpected token") || msg.includes("invalid json") || msg.includes("parse")) return "parse_error";
+  if (msg.includes("api error") || msg.includes("500") || msg.includes("503")) return "api_error";
+  return "unknown";
+}
+
+/**
+ * Report an error to telemetry with bounded category and class.
+ */
+export function reportError(
+  category: "audit" | "setup" | "hook" | "mcp_tool" | "auto_update",
+  errorClass: ErrorClass,
+  fatal: boolean,
+): void {
+  sendTelemetry("error", { category, error_class: errorClass, fatal });
+}
+
+// --- Test helpers (exported for unit tests, not for production) ---
+
+/** @internal Reset cached state. Used in tests only. */
+export function _resetForTests(): void {
+  cachedMid = null;
+  processStartupSent = false;
+  cachedSource = null;
+}
+
+/** @internal Get the resolved mid file path. Used in tests only. */
+export function _getMidFilePath(): string {
+  return getMidFile();
+}
+
+/** @internal Get the resolved queue file path. Used in tests only. */
+export function _getQueueFilePath(): string {
+  return getQueueFile();
+}
+
+/** @internal Get the resolved last-version file path. Used in tests only. */
+export function _getLastVersionFilePath(): string {
+  return getLastVersionFile();
+}

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -34,6 +34,10 @@ export interface InitResult {
   cost: CostInfo;
   durationMs: number;
   errors: string[];
+  /** Number of LLM scanners that actually executed (max 4: oracle/decision/safety/deploy). 0 in deterministic-only fallback. Used for telemetry. */
+  scannersRun: number;
+  /** Number of LLM scanners that failed (rejected or returned an error). Used for telemetry. */
+  scannersFailed: number;
 }
 
 /**
@@ -61,6 +65,7 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
         memories: { count: listMemories(projectPath).length, fromPresets: 0 },
         safety: { created: false, llm: true, summary: "already initialized" },
         config: false, cost: zeroCost(), durationMs: 0, errors: [],
+        scannersRun: 0, scannersFailed: 0,
       };
     }
   }
@@ -77,6 +82,7 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
       memories: { count: 0, fromPresets: 0 },
       safety: { created: false, llm: false, summary: "setup already running" },
       config: false, cost: zeroCost(), durationMs: 0, errors: ["Setup already in progress"],
+      scannersRun: 0, scannersFailed: 0,
     };
   }
   atomicWrite(lockPath, new Date().toISOString());
@@ -172,8 +178,14 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
 
   // Process results
   log(`  [${projectName}] Scanners complete, processing results...`);
+  // Telemetry counters: how many of the 4 scanners actually ran (non-skipped)
+  // and how many failed (rejected). Used by setup_complete telemetry payload.
+  let scannersRun = 0;
+  let scannersFailed = 0;
   for (const settled of scanners) {
     if (settled.status === "rejected") {
+      scannersFailed++;
+      scannersRun++;
       const err = settled.reason;
       const msg = err?.message ?? String(err);
       const stack = err?.stack ? `\n${err.stack.split("\n").slice(0, 3).join("\n")}` : "";
@@ -182,6 +194,7 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
     }
     const val = settled.value;
     if ("skipped" in val) continue;
+    scannersRun++;
 
     if (val.type === "oracle" && val.result) {
       writeOracleFiles(projectPath, val.result.files);
@@ -263,6 +276,8 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
     cost: totalCost,
     durationMs: Date.now() - startTime,
     errors,
+    scannersRun,
+    scannersFailed,
   };
 }
 
@@ -352,6 +367,8 @@ export async function initWorkspaceWithLLM(workspacePath: string, opts?: {
             cost: zeroCost(),
             durationMs: 0,
             errors: [`Init failed: ${settled.reason?.message ?? settled.reason}`],
+            scannersRun: 0,
+            scannersFailed: 4,
           });
         }
       }
@@ -420,5 +437,6 @@ export function initProjectDeterministic(projectPath: string, opts?: { presets?:
     memories: { count: listMemories(projectPath).length, fromPresets: presetsMemoryCount },
     safety: { created: true, llm: false, summary: "" },
     config: configCreated, cost: zeroCost(), durationMs: Date.now() - startTime, errors: [],
+    scannersRun: 0, scannersFailed: 0,
   };
 }

--- a/src/tools/safety-tools.ts
+++ b/src/tools/safety-tools.ts
@@ -3,6 +3,7 @@
  */
 
 import { updateSafetyRule, showSafety, safetyContext } from "../storage/safety.js";
+import { logSafetyUpdated } from "../storage/worklog.js";
 
 export type SafetyRuleType = "git_protected_branch" | "bash_deny" | "bash_allow" | "fs_deny" | "fs_readonly";
 
@@ -10,8 +11,12 @@ export function updateSafetyTool(
   projectPath: string,
   ruleType: SafetyRuleType,
   value: string,
+  sessionId?: string,
 ): { updated: boolean; ruleType: string; value: string } {
   updateSafetyRule(projectPath, ruleType, value);
+  if (sessionId) {
+    logSafetyUpdated(projectPath, sessionId, ruleType, value);
+  }
   return { updated: true, ruleType, value };
 }
 

--- a/src/tools/status.ts
+++ b/src/tools/status.ts
@@ -31,6 +31,7 @@ export function statusTool(projectPath: string): string {
     `Decisions: ${decisions.length} recorded`,
     `  Required: ${decisions.filter(d => d.enforce === "required").length}`,
     `  Advisory: ${decisions.filter(d => d.enforce === "advisory").length}`,
+    `  Other:    ${decisions.filter(d => d.enforce !== "required" && d.enforce !== "advisory").length}`,
     `Memories: ${memories.length} total`,
     `  Feedback: ${memories.filter(m => m.type === "feedback").length}`,
     `  Patterns: ${memories.filter(m => m.type === "pattern").length}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,6 +158,7 @@ export type WorklogEventType =
   | "session_end"
   | "session_orphan_audit_queued"
   | "safety_block"
+  | "safety_updated"
   | "check_result"
   | "audit_complete"
   | "decision_saved"

--- a/src/utils/agent-options.ts
+++ b/src/utils/agent-options.ts
@@ -71,5 +71,11 @@ export function buildAgentQueryOptions(base: {
     allowedTools: tools.allowed,
     disallowedTools: tools.disallowed,
     includePartialMessages: true,
+    // Disable telemetry in spawned subprocesses. Sub-claude sessions started
+    // by scanners/auditors may pick up the parent's .mcp.json and re-launch
+    // axme-code as an MCP server. Each re-launch would otherwise fire its
+    // own startup event, inflating DAU and skewing scanner cost metrics.
+    // The parent process owns the lifecycle event for this user action.
+    env: { ...process.env, AXME_TELEMETRY_DISABLED: "1", AXME_SKIP_HOOKS: "1" },
   };
 }

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -437,4 +437,352 @@ describe("reportError", () => {
 
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
+
+  it("payload contains no raw error message or stack", async () => {
+    let received: any = null;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try { received = JSON.parse(body); } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    reportError("hook", "network_error", false);
+    await new Promise((r) => setTimeout(r, 300));
+
+    assert.ok(received);
+    const event = received.events[0];
+    // Required fields only
+    assert.deepStrictEqual(
+      Object.keys(event).sort(),
+      ["arch", "category", "ci", "error_class", "event", "fatal", "mid", "os", "source", "ts", "version"].sort(),
+    );
+    // No stack or message field
+    assert.equal(event.message, undefined);
+    assert.equal(event.stack, undefined);
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});
+
+// --- Lifecycle: install/startup/update with strict counts ---
+
+describe("lifecycle events strict counts", () => {
+  it("first run fires exactly 1 install + 1 startup, no update", async () => {
+    const events: any[] = [];
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        try {
+          const p = JSON.parse(body);
+          if (Array.isArray(p.events)) events.push(...p.events);
+        } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    await sendStartupEvents();
+
+    const installs = events.filter(e => e.event === "install");
+    const startups = events.filter(e => e.event === "startup");
+    const updates = events.filter(e => e.event === "update");
+    assert.equal(installs.length, 1, "exactly 1 install on first run");
+    assert.equal(startups.length, 1, "exactly 1 startup on first run");
+    assert.equal(updates.length, 0, "no update on first run");
+
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("second run fires only 1 startup, no install", async () => {
+    const events: any[] = [];
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        try {
+          const p = JSON.parse(body);
+          if (Array.isArray(p.events)) events.push(...p.events);
+        } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    // First run: create the mid file via getOrCreateMid
+    getOrCreateMid();
+    // Need to also write last-version to simulate previous run
+    writeLastVersion("0.0.0-dev"); // matches AXME_CODE_VERSION in test
+    _resetForTests();
+
+    await sendStartupEvents();
+
+    const installs = events.filter(e => e.event === "install");
+    const startups = events.filter(e => e.event === "startup");
+    const updates = events.filter(e => e.event === "update");
+    assert.equal(installs.length, 0, "no install on second run");
+    assert.equal(startups.length, 1, "exactly 1 startup on second run");
+    assert.equal(updates.length, 0, "no update if version unchanged");
+
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("update fires exactly 1 update with previous_version field when version changed", async () => {
+    const events: any[] = [];
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        try {
+          const p = JSON.parse(body);
+          if (Array.isArray(p.events)) events.push(...p.events);
+        } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    // Simulate prior install with old version
+    getOrCreateMid();
+    writeLastVersion("0.2.5");
+    _resetForTests();
+
+    await sendStartupEvents();
+
+    const updates = events.filter(e => e.event === "update");
+    assert.equal(updates.length, 1, "exactly 1 update when version changed");
+    assert.equal(updates[0].previous_version, "0.2.5", "update has previous_version");
+
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("repeated sendStartupEvents calls in same process are no-op (processStartupSent guard)", async () => {
+    const events: any[] = [];
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        try {
+          const p = JSON.parse(body);
+          if (Array.isArray(p.events)) events.push(...p.events);
+        } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    await sendStartupEvents();
+    await sendStartupEvents();
+    await sendStartupEvents();
+
+    const startups = events.filter(e => e.event === "startup");
+    assert.equal(startups.length, 1, "exactly 1 startup despite 3 calls");
+
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+});
+
+// --- ci field in payloads ---
+
+describe("ci field detection in events", () => {
+  it("ci=true ends up in sent event when CI env is set", async () => {
+    process.env.CI = "true";
+    let received: any = null;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        try { received = JSON.parse(body); } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    sendTelemetry("startup");
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.ok(received, "request received");
+    assert.equal(received.events[0].ci, true, "ci=true in payload");
+
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("ci=false in payload by default (no CI env)", async () => {
+    let received: any = null;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        try { received = JSON.parse(body); } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    sendTelemetry("startup");
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.ok(received, "request received");
+    assert.equal(received.events[0].ci, false, "ci=false default");
+
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+});
+
+// --- Phase 2 payload shapes ---
+
+describe("audit_complete payload shape", () => {
+  it("has all 10 spec fields when sent", async () => {
+    let received: any = null;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        try { received = JSON.parse(body); } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    sendTelemetry("audit_complete", {
+      outcome: "success",
+      duration_ms: 100000,
+      prompt_tokens: 50000,
+      cost_usd: 0.42,
+      chunks: 1,
+      memories_saved: 2,
+      decisions_saved: 1,
+      safety_saved: 0,
+      dropped_count: 0,
+      error_class: null,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.ok(received);
+    const event = received.events[0];
+    // All 10 audit_complete fields per spec
+    for (const field of [
+      "outcome", "duration_ms", "prompt_tokens", "cost_usd", "chunks",
+      "memories_saved", "decisions_saved", "safety_saved", "dropped_count", "error_class",
+    ]) {
+      assert.ok(field in event, `audit_complete must contain ${field}`);
+    }
+    // Common fields
+    for (const field of ["event", "version", "source", "os", "arch", "ci", "mid", "ts"]) {
+      assert.ok(field in event, `audit_complete must contain common ${field}`);
+    }
+
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+});
+
+describe("setup_complete payload shape", () => {
+  it("has all 9 spec fields when sent", async () => {
+    let received: any = null;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => { body += c; });
+      req.on("end", () => {
+        try { received = JSON.parse(body); } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    sendTelemetry("setup_complete", {
+      outcome: "success",
+      duration_ms: 30000,
+      method: "llm",
+      scanners_run: 4,
+      scanners_failed: 0,
+      phase_failed: null,
+      presets_applied: 2,
+      is_workspace: false,
+      child_repos: 0,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.ok(received);
+    const event = received.events[0];
+    // All 9 setup_complete fields per spec
+    for (const field of [
+      "outcome", "duration_ms", "method", "scanners_run", "scanners_failed",
+      "phase_failed", "presets_applied", "is_workspace", "child_repos",
+    ]) {
+      assert.ok(field in event, `setup_complete must contain ${field}`);
+    }
+
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+});
+
+// --- Queue cap ---
+
+describe("offline queue cap", () => {
+  it("caps queue at 100 events, drops oldest when over cap", async () => {
+    process.env.AXME_TELEMETRY_ENDPOINT = "http://127.0.0.1:1/dead";
+    // Send 105 events, none will succeed (network closed)
+    for (let i = 0; i < 105; i++) {
+      sendTelemetry("startup", { test_seq: i });
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+
+    const queuePath = _getQueueFilePath();
+    assert.equal(existsSync(queuePath), true, "queue file exists");
+    const lines = readFileSync(queuePath, "utf-8").trim().split("\n");
+    assert.ok(lines.length <= 100, `queue must be capped at 100, got ${lines.length}`);
+    // Oldest events dropped: first event in file should NOT be test_seq 0
+    if (lines.length === 100) {
+      const first = JSON.parse(lines[0]);
+      assert.ok(first.test_seq >= 5, `oldest 5 events dropped, first should have test_seq >= 5, got ${first.test_seq}`);
+    }
+  });
+});
+
+// --- classifyError extra coverage ---
+
+describe("classifyError extra slugs", () => {
+  it("classifies api_error", () => {
+    assert.equal(classifyError(new Error("API error: 500 internal")), "api_error");
+    assert.equal(classifyError(new Error("HTTP 503 Service Unavailable")), "api_error");
+  });
+
+  it("classifies disk_full", () => {
+    assert.equal(classifyError(new Error("ENOSPC: no space left on device")), "disk_full");
+  });
+
+  it("classifies permission_denied", () => {
+    assert.equal(classifyError(new Error("EACCES: permission denied")), "permission_denied");
+  });
 });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Tests for src/telemetry.ts.
+ *
+ * Strategy: point AXME_TELEMETRY_STATE_DIR at a per-test temp directory and
+ * AXME_TELEMETRY_ENDPOINT at a local HTTP server stub. Each test exercises one
+ * concrete behavior (mid generation, opt-out, queue, classifyError, etc.).
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server } from "node:http";
+
+import {
+  classifyError,
+  detectSource,
+  isCI,
+  isTelemetryDisabled,
+  getOrCreateMid,
+  readLastVersion,
+  writeLastVersion,
+  sendTelemetry,
+  sendStartupEvents,
+  reportError,
+  _resetForTests,
+  _getMidFilePath,
+  _getQueueFilePath,
+  _getLastVersionFilePath,
+} from "../src/telemetry.ts";
+
+// --- Test fixtures ---
+
+let testDir: string;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "axme-telemetry-test-"));
+  // Snapshot env vars we mutate
+  originalEnv = {
+    AXME_TELEMETRY_STATE_DIR: process.env.AXME_TELEMETRY_STATE_DIR,
+    AXME_TELEMETRY_DISABLED: process.env.AXME_TELEMETRY_DISABLED,
+    AXME_TELEMETRY_ENDPOINT: process.env.AXME_TELEMETRY_ENDPOINT,
+    DO_NOT_TRACK: process.env.DO_NOT_TRACK,
+    CLAUDE_PLUGIN_ROOT: process.env.CLAUDE_PLUGIN_ROOT,
+    CI: process.env.CI,
+    GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+  };
+  process.env.AXME_TELEMETRY_STATE_DIR = testDir;
+  delete process.env.AXME_TELEMETRY_DISABLED;
+  delete process.env.AXME_TELEMETRY_ENDPOINT;
+  delete process.env.DO_NOT_TRACK;
+  delete process.env.CLAUDE_PLUGIN_ROOT;
+  delete process.env.CI;
+  delete process.env.GITHUB_ACTIONS;
+  _resetForTests();
+});
+
+afterEach(() => {
+  // Restore env
+  for (const [k, v] of Object.entries(originalEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(testDir, { recursive: true, force: true });
+  _resetForTests();
+});
+
+// --- Mid generation ---
+
+describe("getOrCreateMid", () => {
+  it("generates a 64-hex mid on first call", () => {
+    const { mid, isNew } = getOrCreateMid();
+    assert.equal(isNew, true);
+    assert.match(mid, /^[0-9a-f]{64}$/);
+  });
+
+  it("persists mid to disk", () => {
+    const { mid } = getOrCreateMid();
+    const filePath = _getMidFilePath();
+    assert.equal(existsSync(filePath), true);
+    assert.equal(readFileSync(filePath, "utf-8").trim(), mid);
+  });
+
+  it("sets file mode 0600", () => {
+    getOrCreateMid();
+    const mode = statSync(_getMidFilePath()).mode & 0o777;
+    assert.equal(mode, 0o600);
+  });
+
+  it("returns same mid on second call (cached)", () => {
+    const { mid: mid1 } = getOrCreateMid();
+    const { mid: mid2, isNew } = getOrCreateMid();
+    assert.equal(mid1, mid2);
+    assert.equal(isNew, false);
+  });
+
+  it("returns existing mid from disk after reset", () => {
+    const { mid: mid1 } = getOrCreateMid();
+    _resetForTests();
+    const { mid: mid2, isNew } = getOrCreateMid();
+    assert.equal(mid1, mid2);
+    assert.equal(isNew, false);
+  });
+
+  it("regenerates mid when file is corrupt", () => {
+    writeFileSync(_getMidFilePath(), "not-a-valid-hex-string\n");
+    _resetForTests();
+    const { mid, isNew } = getOrCreateMid();
+    assert.match(mid, /^[0-9a-f]{64}$/);
+    assert.equal(isNew, true);
+  });
+});
+
+// --- Opt-out ---
+
+describe("isTelemetryDisabled", () => {
+  it("returns false by default", () => {
+    assert.equal(isTelemetryDisabled(), false);
+  });
+
+  it("returns true when AXME_TELEMETRY_DISABLED is set", () => {
+    process.env.AXME_TELEMETRY_DISABLED = "1";
+    assert.equal(isTelemetryDisabled(), true);
+  });
+
+  it("returns true when DO_NOT_TRACK is set", () => {
+    process.env.DO_NOT_TRACK = "1";
+    assert.equal(isTelemetryDisabled(), true);
+  });
+});
+
+// --- Source detection ---
+
+describe("detectSource", () => {
+  it("returns 'binary' when CLAUDE_PLUGIN_ROOT is not set", () => {
+    assert.equal(detectSource(), "binary");
+  });
+
+  it("returns 'plugin' when CLAUDE_PLUGIN_ROOT is set", () => {
+    process.env.CLAUDE_PLUGIN_ROOT = "/some/path";
+    _resetForTests();
+    assert.equal(detectSource(), "plugin");
+  });
+});
+
+// --- CI detection ---
+
+describe("isCI", () => {
+  it("returns false by default", () => {
+    assert.equal(isCI(), false);
+  });
+
+  it("returns true when CI=1", () => {
+    process.env.CI = "1";
+    assert.equal(isCI(), true);
+  });
+
+  it("returns true when GITHUB_ACTIONS is set", () => {
+    process.env.GITHUB_ACTIONS = "true";
+    assert.equal(isCI(), true);
+  });
+});
+
+// --- Last version tracking ---
+
+describe("last version tracking", () => {
+  it("returns null when no last-version file exists", () => {
+    assert.equal(readLastVersion(), null);
+  });
+
+  it("writes and reads back last version", () => {
+    writeLastVersion("0.2.5");
+    assert.equal(readLastVersion(), "0.2.5");
+  });
+
+  it("overwrites existing last version", () => {
+    writeLastVersion("0.2.5");
+    writeLastVersion("0.2.6");
+    assert.equal(readLastVersion(), "0.2.6");
+  });
+});
+
+// --- classifyError ---
+
+describe("classifyError", () => {
+  it("classifies prompt-too-long errors", () => {
+    assert.equal(classifyError(new Error("Prompt is too long for context window")), "prompt_too_long");
+    assert.equal(classifyError(new Error("max tokens exceeded")), "prompt_too_long");
+    assert.equal(classifyError(new Error("Context length 200000 exceeded")), "prompt_too_long");
+  });
+
+  it("classifies rate limit errors", () => {
+    assert.equal(classifyError(new Error("Rate limit reached")), "api_rate_limit");
+    assert.equal(classifyError(new Error("HTTP 429 Too Many Requests")), "api_rate_limit");
+  });
+
+  it("classifies auth errors", () => {
+    assert.equal(classifyError(new Error("Authentication failed")), "oauth_missing");
+    assert.equal(classifyError(new Error("Missing API key")), "oauth_missing");
+  });
+
+  it("classifies timeout errors", () => {
+    assert.equal(classifyError(new Error("Operation timed out")), "timeout");
+    assert.equal(classifyError(new Error("Request aborted")), "timeout");
+  });
+
+  it("classifies network errors", () => {
+    assert.equal(classifyError(new Error("ECONNREFUSED")), "network_error");
+    assert.equal(classifyError(new Error("fetch failed")), "network_error");
+  });
+
+  it("classifies file not found errors", () => {
+    assert.equal(classifyError(new Error("ENOENT: transcript not found")), "transcript_not_found");
+  });
+
+  it("classifies parse errors", () => {
+    assert.equal(classifyError(new Error("Unexpected token in JSON")), "parse_error");
+    assert.equal(classifyError(new Error("Invalid JSON output")), "parse_error");
+  });
+
+  it("returns 'unknown' for unrecognized errors", () => {
+    assert.equal(classifyError(new Error("something completely random")), "unknown");
+    assert.equal(classifyError("string error"), "unknown");
+    assert.equal(classifyError(null), "unknown");
+  });
+
+  it("never throws on weird inputs", () => {
+    assert.equal(classifyError(undefined), "unknown");
+    assert.equal(classifyError(42), "unknown");
+    assert.equal(classifyError({ foo: "bar" }), "unknown");
+  });
+});
+
+// --- HTTP send + queue ---
+
+describe("sendTelemetry with HTTP stub", () => {
+  let server: Server;
+  let receivedRequests: Array<{ events: any[] }>;
+
+  beforeEach(async () => {
+    receivedRequests = [];
+    server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try { receivedRequests.push(JSON.parse(body)); } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr && typeof addr === "object") {
+      process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${addr.port}/v1/telemetry/events`;
+    }
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("sends startup event with required common fields", async () => {
+    sendTelemetry("startup");
+    // Wait for setImmediate + fetch
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(receivedRequests.length, 1);
+    const event = receivedRequests[0].events[0];
+    assert.equal(event.event, "startup");
+    assert.match(event.mid, /^[0-9a-f]{64}$/);
+    assert.ok(event.version);
+    assert.ok(event.os);
+    assert.ok(event.arch);
+    assert.equal(typeof event.ci, "boolean");
+    assert.ok(event.ts);
+    assert.ok(["binary", "plugin"].includes(event.source));
+  });
+
+  it("sends audit_complete event with payload fields", async () => {
+    sendTelemetry("audit_complete", {
+      outcome: "success",
+      duration_ms: 12345,
+      memories_saved: 2,
+      decisions_saved: 1,
+      safety_saved: 0,
+      dropped_count: 0,
+      cost_usd: 1.23,
+      prompt_tokens: 50000,
+      chunks: 1,
+      error_class: null,
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(receivedRequests.length, 1);
+    const event = receivedRequests[0].events[0];
+    assert.equal(event.event, "audit_complete");
+    assert.equal(event.outcome, "success");
+    assert.equal(event.memories_saved, 2);
+    assert.equal(event.cost_usd, 1.23);
+  });
+
+  it("does NOT send when AXME_TELEMETRY_DISABLED is set", async () => {
+    process.env.AXME_TELEMETRY_DISABLED = "1";
+    sendTelemetry("startup");
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(receivedRequests.length, 0);
+  });
+
+  it("does NOT send when DO_NOT_TRACK is set", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    sendTelemetry("startup");
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(receivedRequests.length, 0);
+  });
+
+  it("does NOT generate mid file when disabled", async () => {
+    process.env.AXME_TELEMETRY_DISABLED = "1";
+    sendTelemetry("startup");
+    sendStartupEvents();
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(existsSync(_getMidFilePath()), false);
+  });
+
+  it("queues event to disk when network fails", async () => {
+    // Stop the server so request fails
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    process.env.AXME_TELEMETRY_ENDPOINT = "http://127.0.0.1:1/dead-endpoint";
+
+    sendTelemetry("startup");
+    await new Promise((r) => setTimeout(r, 500));
+
+    const queuePath = _getQueueFilePath();
+    assert.equal(existsSync(queuePath), true);
+    const lines = readFileSync(queuePath, "utf-8").trim().split("\n");
+    assert.equal(lines.length, 1);
+    const queued = JSON.parse(lines[0]);
+    assert.equal(queued.event, "startup");
+  });
+
+  it("flushes queue on next successful send", async () => {
+    // First, fail and queue
+    const port = (server.address() as any).port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    process.env.AXME_TELEMETRY_ENDPOINT = "http://127.0.0.1:1/dead";
+    sendTelemetry("startup", { test: "first" });
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Verify queue has 1 event
+    assert.equal(existsSync(_getQueueFilePath()), true);
+
+    // Restart server on a new port and point endpoint at it
+    server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try { receivedRequests.push(JSON.parse(body)); } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const newPort = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${newPort}/v1/telemetry/events`;
+
+    // Send again — should ship queued + new in one batch
+    receivedRequests.length = 0;
+    sendTelemetry("startup", { test: "second" });
+    await new Promise((r) => setTimeout(r, 300));
+
+    assert.equal(receivedRequests.length, 1);
+    assert.equal(receivedRequests[0].events.length, 2);
+    // Queue should be cleared
+    assert.equal(existsSync(_getQueueFilePath()), false);
+  });
+});
+
+// --- sendStartupEvents lifecycle ---
+
+describe("sendStartupEvents", () => {
+  it("is idempotent within a single process", async () => {
+    let callCount = 0;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try { JSON.parse(body); callCount++; } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    sendStartupEvents();
+    sendStartupEvents();
+    sendStartupEvents();
+    await new Promise((r) => setTimeout(r, 300));
+
+    // First call sends install + startup (2 batches with batch limit), second/third calls do nothing
+    // We can't strictly count because batching is async, but it must be more than 0 and not 9
+    assert.ok(callCount >= 1);
+    assert.ok(callCount <= 4);
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});
+
+// --- reportError ---
+
+describe("reportError", () => {
+  it("sends an error event with category, error_class, fatal", async () => {
+    let received: any = null;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try { received = JSON.parse(body); } catch { /* ignore */ }
+        res.statusCode = 200;
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const port = (server.address() as any).port;
+    process.env.AXME_TELEMETRY_ENDPOINT = `http://127.0.0.1:${port}/v1/telemetry/events`;
+
+    reportError("audit", "prompt_too_long", true);
+    await new Promise((r) => setTimeout(r, 300));
+
+    assert.ok(received);
+    const event = received.events[0];
+    assert.equal(event.event, "error");
+    assert.equal(event.category, "audit");
+    assert.equal(event.error_class, "prompt_too_long");
+    assert.equal(event.fatal, true);
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

Adds anonymous telemetry client to axme-code (`src/telemetry.ts`) that sends:

**Phase 1 — adoption metrics**
- `install` — first run on a machine
- `startup` — MCP server / user-facing CLI boot
- `update` — version changed since last run

**Phase 2 — product health**
- `audit_complete` — counts of memories/decisions/safety saved, dropped_count, cost, duration, error_class
- `setup_complete` — outcome, method, scanners_run/failed, phase_failed, etc.
- `error` — bounded category + error_class slug for caught exceptions

Includes fixes for four pre-existing bugs surfaced during E2E verification.

## Static audit

| Event | Location | Status |
|---|---|---|
| `install` | `src/telemetry.ts:380` | ✅ guarded by `isNew` + `processStartupSent` |
| `startup` | `src/telemetry.ts:387` | ✅ `processStartupSent` boolean guard |
| `update` | `src/telemetry.ts:384` | ✅ `previous_version` field present |
| `audit_complete` | `src/session-cleanup.ts:820` | ✅ all 10 spec fields |
| `setup_complete` | `src/cli.ts:307` | ✅ all 9 spec fields (after fix) |
| `error` | 6 sites: `auto-update.ts`, `cli.ts`, `hooks/{pre,post}-tool-use.ts`, `hooks/session-end.ts`, `server.ts` (mcp_tool wrapper) | ✅ bounded `classifyError` slug |

**Anti-pattern checks:** ✅ no raw error messages in payloads, no paths/PII, no blocking await on hot path, idempotent, CI bit detected, subprocess telemetry suppressed.

## Bugs fixed

1. **`setup_complete` missing `scanners_run`/`scanners_failed`** — added counters to `InitResult`, threaded through cli.ts.
2. **`mcp_tool` error category not wired** — wrapped `server.tool()` once with monkey-patch so all 19 tool handlers auto-report on throw.
3. **`axme_finalize_close` did not spawn auditor** (pre-existing) — now spawns `spawnDetachedAuditWorker` directly so audits run without waiting for SessionEnd hook or MCP cleanup.
4. **`auditStatus` missing from meta after finalize_close** (pre-existing) — fixed together with #3; worker now claims pending state itself.
5. **`axme_status` arithmetic did not sum** (pre-existing) — added `Other:` line for null-enforce decisions so Required + Advisory + Other == total.
6. **`axme_update_safety` did not emit worklog event** (pre-existing) — added `logSafetyUpdated` helper, threaded sessionId through MCP handler.

## Test summary

| Suite | Result |
|---|---|
| `npm test` | ✅ **475 tests, 104 suites, 0 failures** (412 base + 15 parser + 48 telemetry) |
| `npm run lint` | ✅ clean |
| `npm run build` | ✅ clean |
| `npx tsc --noEmit` | ✅ clean |

48 telemetry unit tests cover: mid generation/persistence/regen, opt-out (AXME_TELEMETRY_DISABLED + DO_NOT_TRACK), source/CI detection, last-version tracking, classifyError vocabulary, HTTP send + offline queue + flush, queue cap at 100, sendStartupEvents idempotency, ci=true/false in real payloads, audit_complete + setup_complete payload shape validation, reportError no-PII guarantee.

## Staging E2E

7/7 scenarios passed against `axme-gateway-staging-uc2bllq3la-uc.a.run.app/v1/telemetry/events`:

- A: first run sends install + startup, mid file created
- B: rerun reuses mid, no install
- C: update event fires when last-version differs, previous_version field present
- E: setup_complete (auth-fail fast path) ships to staging
- F: error events covered by H (offline queue → flush)
- G: AXME_TELEMETRY_DISABLED=1 + DO_NOT_TRACK=1 leave no state, no network
- H: bogus endpoint queues events, real endpoint flushes queue

**Scenario D — real audit_complete on staging:** ran live LLM `audit-session` subprocess on session `d5e6391c` (15.5MB transcript, verify-only mode). Result:
```
outcome: success
durationMs: 574371 (~9.5 min)
promptTokens: 130731
costUsd: 1.0232553
chunks: 1
memories_saved: 0
decisions_saved: 1
safety_saved: 0
dropped_count: 0
```
audit_complete event landed on staging, telemetry-queue.jsonl absent post-run.

**Anti-spam check:** full MCP boot (initialize + tools/list + 3 tool calls + shutdown) produces exactly **1 install + 1 startup**. No duplicates from subprocess paths.

## Test plan

- [x] Lint clean
- [x] Build clean
- [x] tsc --noEmit clean
- [x] Unit tests pass (475/475)
- [x] Staging E2E (7 scenarios + Scenario D real audit)
- [x] Anti-spam verification (1 boot = 1 install + 1 startup)
- [x] Manual verification by test agent on isolated tmp project (previous round)

## Open issues (not blocking merge)

- Privacy policy on code.axme.ai needs telemetry disclosure section. Tracked in axme-code-site backlog as B-001 (high priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)