### PR TITLE
release: v0.2.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axme-code",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "(Alpha) Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.",
   "author": {
     "name": "AXME AI",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.2.7] - 2026-04-10
+
+### Added
+- **Anonymous telemetry client** (`src/telemetry.ts`): Phase 1 lifecycle events (`install`, `startup`, `update`) and Phase 2 product-health events (`audit_complete`, `setup_complete`, `error`). Sends to AXME control plane at `https://api.cloud.axme.ai/v1/telemetry/events`. (#97)
+- **Opt-out via environment**: `AXME_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1` (industry standard) fully disables — no machine ID generated, no network calls, no persistent state. Documented in README. (#97)
+- **Anonymous machine ID**: 64-char random hex at `~/.local/share/axme-code/machine-id` (mode 0600), not derived from hardware. Regenerated on file corruption. (#97)
+- **Offline queue**: Failed sends append to `telemetry-queue.jsonl` (cap 100, oldest dropped), flushed on next successful send. (#97)
+- **Bounded error vocabulary** (`classifyError`): maps caught exceptions to one of 12 slugs (`prompt_too_long`, `oauth_missing`, `network_error`, `parse_error`, etc.) — never sends raw exception messages. (#97)
+- **Session close feedback request**: After `axme_finalize_close`, agent shows feedback request to user (GitHub stars, issues, hello@axme.ai). (#96)
+- **Two-phase auditor**: Replaces single-call audit with free-text analysis (`runSingleAuditCall`) + structured formatting via second SDK call. Eliminates parser-drop-everything failures on long transcripts. (#96)
+- **`droppedCount` field** in `parseAuditOutput`: counts blocks the parser dropped due to missing required fields, surfaced in `audit_complete` telemetry as early-warning for format drift. (#96, #97)
+- **15 unit tests for JSON audit parser** + **48 unit tests for telemetry module** (mid generation, opt-out, queue, classifyError, payload shapes, ci detection). Total test count: 412 → 475. (#96, #97)
+
+### Fixed
+- **`axme_finalize_close` did not spawn auditor**: pre-existing bug. The MCP tool only set `agentClosed=true` and returned, leaving the audit to run only when SessionEnd hook fired (often killed by VS Code) or MCP server eventually exited. Now spawns `spawnDetachedAuditWorker` directly so audits run in verify-only mode immediately. (#96)
+- **`auditStatus` missing from `meta.json` after finalize_close**: same root cause as above. The detached worker now claims `pending` state itself in `runSessionCleanup` (avoids self-dedup race). (#96)
+- **`axme_status` arithmetic did not sum to total**: 6 decisions with `enforce=null` were not counted in either Required/Advisory line. Added `Other:` line so the three sum to total. (#96)
+- **`axme_update_safety` did not emit worklog event**: `memory_saved` and `decision_saved` were logged but `safety_updated` was not. Added `logSafetyUpdated` helper, `safety_updated` to `WorklogEventType`, threaded `sessionId` through MCP handler into `updateSafetyTool`. (#96)
+- **`setup_complete` payload missing `scanners_run`/`scanners_failed`**: spec required both. Added counters to `InitResult`, threaded through `cli.ts` setup handler. (#97)
+- **`mcp_tool` error category not wired**: `reportError("mcp_tool", ...)` was reserved in the bounded enum but no call site existed. Wrapped `server.tool()` once with monkey-patch so all 19 registered tool handlers auto-fire `error` event with `category=mcp_tool`, `fatal=true` on throw. (#97)
+- **`.mcp.json` formatting normalized** to match `setup` command output (multiline arrays via `JSON.stringify(obj, null, 2)`) so re-running setup leaves no stale diff. (#96)
+- **Plugin README install commands**: replaced `--plugin-dir` (per-session only) with the real install paths (`claude plugin install` from terminal, `/plugin install` from interactive CLI). (#96)
+
+### Changed
+- **`sendStartupEvents` is now `await`-able and uses blocking sends**: under event-loop pressure (parallel LLM scanners), fire-and-forget `setImmediate` callbacks could stall and cause fetch timeouts → false-fail → offline queue → server-side duplicates. Awaiting startup sends sequentially before heavy work begins eliminates this. (#97)
+- **Telemetry network timeout** raised from 5s to 30s: prevents false-fail under heavy load. (#97)
+- **Subprocess telemetry suppression**: `buildAgentQueryOptions` and session-auditor sub SDK queries now inject `AXME_TELEMETRY_DISABLED=1` into child env, so spawned `claude-agent-sdk` subprocesses that re-launch axme-code as MCP server don't fire extra startup events. (#97)
+- **CLI startup events restricted to user-facing commands** (`setup`, `status`, `stats`, `audit-kb`, `cleanup`, `help`). `hook` and `audit-session` subcommands run as short-lived subprocesses many times per session and would spam the endpoint. The `serve` subcommand sends its own startup event from `server.ts` after MCP boot. (#97)
+
 ## [0.2.0] - 2026-04-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axme/code",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Persistent memory, decisions, and safety guardrails for Claude Code",
   "type": "module",
   "main": "./dist/server.js",

--- a/templates/plugin-README.md
+++ b/templates/plugin-README.md
@@ -5,7 +5,7 @@
 Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.
 
 [![Alpha](https://img.shields.io/badge/status-alpha-orange)]()
-[![Version](https://img.shields.io/badge/version-0.2.6-blue)]()
+[![Version](https://img.shields.io/badge/version-0.2.7-blue)]()
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 **[Main Repository](https://github.com/AxmeAI/axme-code)** · **[Website](https://code.axme.ai)** · **[Issues](https://github.com/AxmeAI/axme-code/issues)**


### PR DESCRIPTION
## v0.2.7 — Telemetry release

First release with anonymous client telemetry. Phase 1 lifecycle (install/startup/update) + Phase 2 product health (audit_complete/setup_complete/error). Plus four pre-existing fixes surfaced during E2E verification.

### What's new for users

- **Anonymous telemetry** with full opt-out via `AXME_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`. Documented in README. No PII, no paths, no source code, no IPs. Random 64-char machine ID at `~/.local/share/axme-code/machine-id`.
- **Auditor pipeline now reliable** on long sessions: two-phase audit (free-text analysis + structured formatting) eliminates the parser-drop-everything failures we hit on long transcripts.
- **Session close feedback request**: after `axme_finalize_close`, the agent shows feedback links (GitHub stars, issues, hello@axme.ai).
- **Auditor runs immediately on agent close**: previously waited for SessionEnd hook which often never fired in VS Code.

### Fixes

- `axme_finalize_close` spawns detached auditor directly (was waiting for SessionEnd hook)
- `auditStatus` field now appears in meta.json after agent close
- `axme_status` arithmetic now sums correctly (added `Other:` line for null-enforce decisions)
- `axme_update_safety` now emits `safety_updated` worklog event
- `setup_complete` telemetry payload now includes `scanners_run` / `scanners_failed`
- `mcp_tool` error category now wired via auto-wrapper around `server.tool()`

### Test summary

| Suite | Result |
|---|---|
| `npm test` | ✅ **475 tests, 104 suites, 0 failures** (412 → 475: +15 JSON parser tests, +48 telemetry tests) |
| `npm run lint` | ✅ clean |
| `npm run build` | ✅ clean |

### E2E verification on staging

Telemetry endpoint validated against `axme-gateway-staging`:
- 7/7 lifecycle scenarios passed (install/startup/update/opt-out/offline queue/setup_complete)
- Real audit_complete on session d5e6391c (15.5MB transcript, verify-only mode): outcome=success, duration 9.5min, cost $1.02, 1 decision saved, 0 dropped, all spec fields present in payload
- Anti-spam: full MCP boot + 3 tool calls = exactly 1 install + 1 startup, no duplicates

### Files changed in this release PR

```
.claude-plugin/plugin.json     | version 0.2.6 → 0.2.7
CHANGELOG.md                   | new [0.2.7] section with Added/Fixed/Changed
package.json                   | version 0.2.6 → 0.2.7
templates/plugin-README.md     | version badge 0.2.6 → 0.2.7
```

### Notes for next release

- **CHANGELOG.md must be updated on every release** (D-128, required) — entries between 0.2.0 and 0.2.6 were skipped, found during this release prep. Saved as enforced decision so future release PRs include changelog updates by default.
- Privacy policy on code.axme.ai needs telemetry disclosure section (axme-code-site backlog B-001, high priority).

### Test plan

- [x] Lint clean
- [x] Build clean
- [x] Unit tests pass (475/475)
- [x] Staging E2E (7 lifecycle + Scenario D real audit)
- [x] Anti-spam verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)