### PR TITLE
chore: rename contact email hello@axme.ai to contact@axme.ai

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "description": "(Alpha) Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.",
   "author": {
     "name": "AXME AI",
-    "email": "hello@axme.ai",
+    "email": "contact@axme.ai",
     "url": "https://github.com/AxmeAI"
   },
   "homepage": "https://code.axme.ai",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,4 +78,4 @@ docs/                # Architecture docs and diagrams
 
 ## Questions?
 
-Open an issue or email hello@axme.ai.
+Open an issue or email contact@axme.ai.

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ---
 
-[Website](https://code.axme.ai) · [Issues](https://github.com/AxmeAI/axme-code/issues) · [Architecture](docs/ARCHITECTURE.md) · hello@axme.ai
+[Website](https://code.axme.ai) · [Issues](https://github.com/AxmeAI/axme-code/issues) · [Architecture](docs/ARCHITECTURE.md) · contact@axme.ai
 
 ---
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -948,7 +948,7 @@ server.tool(
       "> AXME Code is in alpha — your feedback shapes the product. If it saved you time today, consider:",
       "> - Star on GitHub: https://github.com/AxmeAI/axme-code",
       "> - Report issues or ideas: https://github.com/AxmeAI/axme-code/issues",
-      "> - Share feedback: hello@axme.ai",
+      "> - Share feedback: contact@axme.ai",
       "> - Support: support@axme.ai",
     ];
 

--- a/templates/plugin-README.md
+++ b/templates/plugin-README.md
@@ -105,4 +105,4 @@ This repo is auto-synced from the main [axme-code](https://github.com/AxmeAI/axm
 
 ---
 
-[Website](https://code.axme.ai) · [Main Repo](https://github.com/AxmeAI/axme-code) · [Issues](https://github.com/AxmeAI/axme-code/issues) · hello@axme.ai
+[Website](https://code.axme.ai) · [Main Repo](https://github.com/AxmeAI/axme-code) · [Issues](https://github.com/AxmeAI/axme-code/issues) · contact@axme.ai


### PR DESCRIPTION
## Summary
Rename public contact email from `hello@axme.ai` to `contact@axme.ai`.

## Context
Coordinated rename across all public-facing AXME repositories (websites, docs, SDK metadata, CLI and server user messages). Part of an org-wide email transition.

## Files changed
- `.claude-plugin/plugin.json`
- `CONTRIBUTING.md`
- `README.md`
- `src/server.ts`
- `templates/plugin-README.md`