### PR TITLE
fix(audit): set pathToClaudeCodeExecutable on all direct SDK call sites (B-006)

### DIFF
--- a/src/agents/memory-extractor.ts
+++ b/src/agents/memory-extractor.ts
@@ -12,6 +12,7 @@
 import type { Memory } from "../types.js";
 import { extractCostFromResult, zeroCost, type CostInfo } from "../utils/cost-extractor.js";
 import { toMemorySlug } from "../storage/memory.js";
+import { findClaudePath } from "../utils/agent-options.js";
 
 export interface MemoryExtractionResult {
   memories: Memory[];
@@ -68,9 +69,11 @@ export async function runMemoryExtraction(opts: {
   const startTime = Date.now();
   const model = opts.model ?? "claude-haiku-4-5";
 
+  const claudePath = findClaudePath();
   const queryOpts = {
     cwd: opts.projectPath,
     model,
+    ...(claudePath ? { pathToClaudeCodeExecutable: claudePath } : {}),
     permissionMode: "bypassPermissions" as const,
     allowDangerouslySkipPermissions: true,
     allowedTools: [] as string[],

--- a/src/agents/session-auditor.ts
+++ b/src/agents/session-auditor.ts
@@ -21,6 +21,7 @@ import { basename, relative } from "node:path";
 import type { Memory, Decision, SessionHandoff, WorkspaceInfo } from "../types.js";
 import { DEFAULT_AUDITOR_MODEL } from "../types.js";
 import { extractCostFromResult, zeroCost, type CostInfo } from "../utils/cost-extractor.js";
+import { findClaudePath } from "../utils/agent-options.js";
 import { toMemorySlug } from "../storage/memory.js";
 import { toSlug, listDecisions } from "../storage/decisions.js";
 import { listMemories } from "../storage/memory.js";
@@ -624,12 +625,14 @@ async function runSingleAuditCall(opts: {
 }> {
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
 
+  const claudePath = findClaudePath();
   const queryOpts = {
     cwd: opts.sessionOrigin,
     model: opts.model,
     systemPrompt: AUDIT_SYSTEM_PROMPT,
     settingSources: [],
     mcpServers: {},
+    ...(claudePath ? { pathToClaudeCodeExecutable: claudePath } : {}),
     permissionMode: "bypassPermissions" as const,
     allowDangerouslySkipPermissions: true,
     allowedTools: ["Read", "Grep", "Glob"],
@@ -883,12 +886,14 @@ JSON SCHEMA:
 ANALYSIS TO FORMAT:
 ${freeTextAnalysis}`;
 
+  const claudePath = findClaudePath();
   const queryOpts = {
     cwd: sessionOrigin,
     model,
     systemPrompt: "You are a JSON formatting assistant. Output only a ```json code fence with the structured data. No other text.",
     settingSources: [] as any[],
     mcpServers: {},
+    ...(claudePath ? { pathToClaudeCodeExecutable: claudePath } : {}),
     permissionMode: "bypassPermissions" as const,
     allowDangerouslySkipPermissions: true,
     allowedTools: [] as string[],

--- a/src/utils/agent-options.ts
+++ b/src/utils/agent-options.ts
@@ -6,9 +6,16 @@ import { execSync } from "node:child_process";
 
 type Options = import("@anthropic-ai/claude-agent-sdk").Options;
 
-/** Find claude binary path. Cached after first lookup. */
+/**
+ * Find claude binary path. Cached after first lookup.
+ *
+ * Exported because the SDK resolves its own path via `import.meta.url`, which
+ * returns undefined inside the bundled CJS build and crashes with
+ * `fileURLToPath(undefined)` (B-006 / D-121). Every direct `sdk.query()` call
+ * site must set `pathToClaudeCodeExecutable` to the result of this function.
+ */
 let _claudePath: string | undefined;
-function findClaudePath(): string | undefined {
+export function findClaudePath(): string | undefined {
   if (_claudePath !== undefined) return _claudePath || undefined;
   try {
     _claudePath = execSync("which claude", { encoding: "utf-8" }).trim();

--- a/test/agent-sdk-paths.test.ts
+++ b/test/agent-sdk-paths.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression guard for B-006 / D-121.
+ *
+ * The Claude Agent SDK resolves its own executable via `import.meta.url`,
+ * which is undefined inside the bundled CJS build and crashes with
+ * `fileURLToPath(undefined)`. Every direct `sdk.query()` call site must
+ * therefore either:
+ *   a) build its options through `buildAgentQueryOptions()` (which sets
+ *      `pathToClaudeCodeExecutable` via `findClaudePath()`), or
+ *   b) import `findClaudePath` and set `pathToClaudeCodeExecutable`
+ *      explicitly on its own options object.
+ *
+ * This test greps every `src/agents/**.ts` file for `sdk.query(` and fails
+ * if none of the two helpers are imported. It is static, so it does not
+ * require the SDK, the `claude` binary, or any network access.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import assert from "node:assert";
+
+const AGENTS_DIR = new URL("../src/agents/", import.meta.url).pathname;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) walk(full, out);
+    else if (entry.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+test("every src/agents file calling sdk.query imports buildAgentQueryOptions or findClaudePath", () => {
+  const files = walk(AGENTS_DIR);
+  const offenders: string[] = [];
+
+  for (const file of files) {
+    const src = readFileSync(file, "utf-8");
+    if (!src.includes("sdk.query(")) continue;
+
+    const hasBuilder = /import\s+[^;]*\bbuildAgentQueryOptions\b[^;]*from\s+["'][^"']*agent-options/.test(src);
+    const hasFinder = /import\s+[^;]*\bfindClaudePath\b[^;]*from\s+["'][^"']*agent-options/.test(src);
+
+    if (!hasBuilder && !hasFinder) {
+      offenders.push(file.replace(AGENTS_DIR, ""));
+    }
+  }
+
+  assert.deepStrictEqual(
+    offenders,
+    [],
+    `The following files call sdk.query() but import neither buildAgentQueryOptions ` +
+    `nor findClaudePath from utils/agent-options. Without pathToClaudeCodeExecutable ` +
+    `the bundled CJS build will crash with fileURLToPath(undefined) (B-006 / D-121):\n` +
+    `  ${offenders.join("\n  ")}`,
+  );
+});
+
+test("session-auditor.ts manual queryOpts include pathToClaudeCodeExecutable", () => {
+  const src = readFileSync(new URL("../src/agents/session-auditor.ts", import.meta.url), "utf-8");
+  const queryOptsBlocks = src.split("const queryOpts = {").slice(1);
+  assert.ok(queryOptsBlocks.length >= 2, "expected at least 2 queryOpts blocks in session-auditor.ts");
+
+  for (const block of queryOptsBlocks) {
+    const untilClose = block.slice(0, block.indexOf("};"));
+    assert.ok(
+      untilClose.includes("pathToClaudeCodeExecutable"),
+      `session-auditor.ts queryOpts block missing pathToClaudeCodeExecutable:\n${untilClose.slice(0, 300)}`,
+    );
+  }
+});
+
+test("memory-extractor.ts manual queryOpts include pathToClaudeCodeExecutable", () => {
+  const src = readFileSync(new URL("../src/agents/memory-extractor.ts", import.meta.url), "utf-8");
+  assert.ok(
+    src.includes("pathToClaudeCodeExecutable"),
+    "memory-extractor.ts must set pathToClaudeCodeExecutable on its queryOpts",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes **B-006**: audit worker in the bundled CJS build crashed on every session close with `TypeError: fileURLToPath(undefined)`. Auto-learning (memories, decisions, safety rules, handoff extraction) was effectively dead on v0.2.7. Telemetry showed 14 consecutive `audit_complete=failed` events on 2026-04-13 from the developer machine; any external user on v0.2.7 hits the same crash.

## Root cause

The Claude Agent SDK resolves its own executable via `import.meta.url`, which is `undefined` in the bundled CJS output and crashes inside `fileURLToPath()`. D-121 fixed this for the main MCP server by setting `pathToClaudeCodeExecutable` in the shared `buildAgentQueryOptions()` helper — but `session-auditor` and `memory-extractor` built their own options objects by hand and bypassed the helper, so the fix never reached the audit path.

Stack trace from `.axme-code/audit-worker-logs/`:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of URL. Received undefined
    at fileURLToPath (node:internal/url:1487:11)
    at HL (/home/georgeb/.local/bin/axme-code:10771:43)
    at runSingleAuditCall (axme-code:57739:18)
    at runSessionAudit (axme-code:57628:25)
    at runSessionCleanup (axme-code:58693:21)
```

## Changes

- `src/utils/agent-options.ts` — export `findClaudePath()` so ad-hoc queryOpts can set `pathToClaudeCodeExecutable` without going through the full builder (different roles want different tool allowlists; the builder is too opinionated for the strict auditor/format/memory paths).
- `src/agents/session-auditor.ts` — import `findClaudePath`, set `pathToClaudeCodeExecutable: claudePath` on both `runSingleAuditCall` and `formatAuditResult` queryOpts.
- `src/agents/memory-extractor.ts` — same fix on `runMemoryExtraction` queryOpts. Currently tree-shaken (no callers), but fixed to keep future reuse safe and consistent.
- `test/agent-sdk-paths.test.ts` (new) — static regression guard. Walks `src/agents/**.ts`, finds every file calling `sdk.query(`, and fails if neither `buildAgentQueryOptions` nor `findClaudePath` is imported. No SDK, no `claude` binary, no network — safe in CI.

## Verification

Static:

- `npm test` — **478/478 pass** (3 new tests in `agent-sdk-paths.test.ts`)
- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `grep pathToClaudeCodeExecutable dist/cli.mjs` → 3 hits (helper + both session-auditor sites)

**End-to-end smoke test on a real failed session (`cb524f4b-8cc9-4e5c-9c50-21930f9001ac`):**

Before fix:

```
auditStatus: failed
auditAttempts: 1
lastAuditError: [runSessionAudit] The \"path\" argument must be of type string or an instance of URL. Received undefined
```

Ran `node dist/cli.mjs audit-session --workspace ... --session cb524f4b...` against the freshly-built bundle. Result:

```json
{
  \"sessionId\": \"cb524f4b-...\",
  \"auditRan\": true,
  \"memories\": 0,
  \"decisions\": 0,
  \"safetyRules\": 0,
  \"handoffSaved\": false,
  \"worklogSummary\": true,
  \"oracleRescanned\": false,
  \"costUsd\": 1.0823125500000004
}
```

After fix:

```
auditStatus: done
auditedAt: 2026-04-14T07:38:31.094Z
lastAuditError: (none)
```

Audit log (`.axme-code/audit-logs/2026-04-14T07-36-55_cb524f4b.json`): `phase: finished`, `promptTokens: 95120`, `chunks: 1`, `durationMs: 95181`, `costUsd: 1.08`. Full LLM round-trip, no crash.

## Test plan

- [x] Local bundle audits a real failed session without crashing
- [ ] Merge, bump to v0.2.8, cut binary release
- [ ] After install of v0.2.8, telemetry: \`audit_complete\` outcome=failed count drops to 0 on v0.2.8 machines

Fixes B-006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)