### PR TITLE
fix(safety): parseAxmeGate strips trailing quote/punct from pr/repo (B-008)

### DIFF
--- a/src/storage/safety.ts
+++ b/src/storage/safety.ts
@@ -329,7 +329,22 @@ export function checkBash(rules: SafetyRules, command: string): SafetyVerdict {
  * sees the full command before execution and parses the metadata.
  *
  * Returns null if no #!axme marker found.
+ *
+ * Value capture: `[^\s"'` + "`" + `]+` rather than `\S+`, so a stray
+ * closing quote/backtick from a surrounding `-m "..."` string doesn't
+ * get glued onto the captured value (B-008). Trailing punctuation
+ * (`)`, `,`, `;`, `.`) is stripped defensively for the same reason —
+ * common when the marker ends up inside a HEREDOC or after a `$(...)`.
  */
+const GATE_VALUE = /[^\s"'`]+/.source;
+const PR_RE = new RegExp(`\\bpr=(${GATE_VALUE})`);
+const REPO_RE = new RegExp(`\\brepo=(${GATE_VALUE})`);
+const TRAILING_PUNCT_RE = /[)\],;.]+$/;
+
+function cleanGateValue(raw: string): string {
+  return raw.replace(TRAILING_PUNCT_RE, "");
+}
+
 export function parseAxmeGate(command: string): { pr: string; repo: string } | null {
   // Use the LAST occurrence of #!axme (the suffix), not one inside a commit message.
   const lastIdx = command.lastIndexOf("#!axme");
@@ -338,16 +353,21 @@ export function parseAxmeGate(command: string): { pr: string; repo: string } | n
   const match = suffix.match(/^#!axme\s+(.*)/);
   if (!match) return null;
   const pairs = match[1].trim();
-  const prMatch = pairs.match(/\bpr=(\S+)/);
-  const repoMatch = pairs.match(/\brepo=(\S+)/);
+  const prMatch = pairs.match(PR_RE);
+  const repoMatch = pairs.match(REPO_RE);
   if (!prMatch || !repoMatch) return null;
-  return { pr: prMatch[1], repo: repoMatch[1] };
+  const pr = cleanGateValue(prMatch[1]);
+  const repo = cleanGateValue(repoMatch[1]);
+  if (!pr || !repo) return null;
+  return { pr, repo };
 }
 
 const AXME_GATE_INSTRUCTION =
   'BLOCKED: git commit/push requires #!axme safety metadata. ' +
   'Retry with: `<your command> #!axme pr=<PR_NUMBER|none> repo=<OWNER/REPO>` ' +
-  '(pr=none if no PR created yet).';
+  '(pr=none if no PR created yet). ' +
+  'Place the marker AFTER the closing `"` of any `-m "..."` argument, ' +
+  'not inside it — otherwise the closing quote gets parsed as part of the repo name.';
 
 /**
  * Check if a PR is merged via gh CLI. Returns true if merged, false otherwise.

--- a/test/axme-gate.test.ts
+++ b/test/axme-gate.test.ts
@@ -81,6 +81,40 @@ describe("parseAxmeGate", () => {
     const result = parseAxmeGate(cmd);
     assert.deepEqual(result, { pr: "42", repo: "AxmeAI/test" });
   });
+
+  // --- B-008 regression: greedy \S+ used to swallow the closing quote ---
+
+  it("strips trailing closing quote when marker is inside -m \"...\" string", () => {
+    // This is the B-008 reproducer: marker placed INSIDE the quoted message.
+    const cmd = 'git commit -m "fix: blah #!axme pr=6 repo=AxmeAI/axme-blog"';
+    const result = parseAxmeGate(cmd);
+    assert.deepEqual(result, { pr: "6", repo: "AxmeAI/axme-blog" });
+  });
+
+  it("strips trailing single quote", () => {
+    const cmd = "git commit -m 'fix #!axme pr=6 repo=AxmeAI/axme-blog'";
+    const result = parseAxmeGate(cmd);
+    assert.deepEqual(result, { pr: "6", repo: "AxmeAI/axme-blog" });
+  });
+
+  it("strips trailing backtick", () => {
+    const cmd = "git commit -m `fix #!axme pr=6 repo=AxmeAI/axme-blog`";
+    const result = parseAxmeGate(cmd);
+    assert.deepEqual(result, { pr: "6", repo: "AxmeAI/axme-blog" });
+  });
+
+  it("strips trailing punctuation like ) and ,", () => {
+    const cmd1 = 'git commit -m "$(echo fix #!axme pr=6 repo=AxmeAI/axme-blog)"';
+    assert.deepEqual(parseAxmeGate(cmd1), { pr: "6", repo: "AxmeAI/axme-blog" });
+    const cmd2 = 'git commit -m "fix #!axme pr=6 repo=AxmeAI/axme-blog,"';
+    assert.deepEqual(parseAxmeGate(cmd2), { pr: "6", repo: "AxmeAI/axme-blog" });
+  });
+
+  it("returns null when stripping leaves an empty value", () => {
+    // pr=" — value is just a quote, after strip nothing left.
+    const cmd = 'git commit -m "x #!axme pr=" repo=AxmeAI/x"';
+    assert.equal(parseAxmeGate(cmd), null);
+  });
 });
 
 // ===== checkGit - gate enforcement =====


### PR DESCRIPTION
## Summary

Fixes **B-008**: when the agent placed `#!axme pr=N repo=OWNER/REPO` *inside* a `git commit -m "..."` quoted string, the safety hook fail-closed on every retry with `Cannot verify PR #N status (gh CLI error)`. The greedy `\S+` regex captured the closing `"` as part of the repo name, then `gh pr view` rejected the malformed value and the hook treated it as a network error.

Discovered live during axme-blog PR #6 work — the agent (me) burned ~6 retry cycles before realising the regex, not the network, was eating the call.

## Root cause

`src/storage/safety.ts:341-344` — `\S+` matched anything non-whitespace including `"`, `'`, `` ` ``. So:

```
git commit -m "fix #!axme pr=6 repo=AxmeAI/axme-blog"
```

→ `repo = "AxmeAI/axme-blog\""` (quote glued on) → `gh pr view 6 --repo "AxmeAI/axme-blog\"" ...` → `gh` rejects → `execSync` throws → `checkAxmeGate` returns fail-closed verdict (correct safety behavior, wrong root cause).

## Fix

`src/storage/safety.ts`:

- Tighten value capture from `\S+` to `[^\s"'`]+` for both `pr=` and `repo=` so quote/backtick characters never end up inside the captured value.
- Defensively strip trailing `)`, `]`, `,`, `;`, `.` after capture (covers `$(...)` expansions, comment lists, other shell punctuation).
- Reject parses where stripping leaves an empty value (returns `null` instead of building a bad lookup).
- `AXME_GATE_INSTRUCTION` now reminds the agent to put the marker AFTER the closing `"` of `-m "..."`, not inside it.

`test/axme-gate.test.ts`:
- B-008 reproducer: marker placed inside `-m "..."` parses cleanly.
- Same for `'...'` and `` `...` ``.
- Trailing `)` and `,` from `$(...)` / comment list also stripped.
- `pr="` alone (nothing left after strip) returns `null` instead of constructing a bad gate.

## Verification

- `npm test` — **489/489 pass** (5 new cases; previous baseline 484)
- `npx tsc --noEmit` — clean
- `npm run build` — clean

## Test plan

- [x] Existing gate tests still pass (no regression on the LAST-marker-wins, HEREDOC, or live `gh` checks)
- [ ] Manual: in a follow-up agent session, place `#!axme` inside `-m "..."` and confirm hook no longer blocks (slated for v0.5.0 release smoke test)

Fixes B-008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
