### PR TITLE
release: v0.2.8 (B-006 + B-007 + B-008 fixes)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axme-code",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "(Alpha) Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.",
   "author": {
     "name": "AXME AI",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.2.8] - 2026-04-14
+
+### Fixed
+- **Audit worker crash on every session close** (B-006): bundled CJS build called the Claude Agent SDK without an explicit `pathToClaudeCodeExecutable`. The SDK resolves its own binary via `import.meta.url`, which is `undefined` in CJS, so it crashed inside `fileURLToPath()` with `TypeError [ERR_INVALID_ARG_TYPE]`. The D-121 fix had landed in `buildAgentQueryOptions()` but `runSingleAuditCall`, `formatAuditResult` and `runMemoryExtraction` built their SDK options by hand and bypassed the helper. Result on v0.2.7: 14+ consecutive `audit_complete=failed` events in telemetry, auto-extraction effectively dead. Fix exports `findClaudePath()` from `src/utils/agent-options.ts` and sets `pathToClaudeCodeExecutable` on all three direct call sites. Smoke-tested on a real failed session: `auditStatus` flipped from `failed` to `done`, full LLM round-trip, no crash. (#105)
+- **`#!axme` safety gate falsely blocked commits when the marker was placed inside `-m "..."` quotes** (B-008): regex `\bpr=(\S+)` and `\brepo=(\S+)` greedily captured the closing quote of the surrounding commit message, producing malformed `gh pr view --repo "OWNER/REPO\""` calls that `gh` rejected. The hook then fail-closed with `Cannot verify PR #N status (gh CLI error)` on every retry. Fix tightens the value capture to forbid quote/backtick characters, defensively strips trailing `)`, `]`, `,`, `;`, `.`, and updates the gate instruction to remind agents that the marker belongs **after** the closing quote. (#107)
+
+### Added
+- **Extended `classifyError` vocabulary** (B-007): added bounded slugs `node_invalid_arg`, `module_not_found`, `spawn_error`, `out_of_memory`, plus generic `type_error` / `reference_error` fallbacks via `err.name`. Match order is load-bearing: specific Node `ERR_*` codes are checked before generic JS error kinds so B-006-class failures keep their triage signal instead of collapsing into `unknown`. Network catches now also include `econnreset`. (#106)
+- **`audit_complete` failures now stamp `category: "audit"` and `fatal: false`** so they land in the backend's `(category, error_class)` composite index. Previously every failed audit had `category=NULL`, making the admin "Top error classes" panel useless for triage — all 16 prod failures over the last 30 days collapsed into a single opaque bucket. (#106)
+
+### Tests
+- 14 new unit tests covering the three fixes (5 in `test/axme-gate.test.ts` for the regex regression, 6 in `test/telemetry.test.ts` for the new error classes, 3 in `test/agent-sdk-paths.test.ts` static guard against any future `sdk.query()` site that forgets `pathToClaudeCodeExecutable`).
+- Total test count: 475 → 489.
+
 ## [0.2.7] - 2026-04-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axme/code",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Persistent memory, decisions, and safety guardrails for Claude Code",
   "type": "module",
   "main": "./dist/server.js",

--- a/templates/plugin-README.md
+++ b/templates/plugin-README.md
@@ -5,7 +5,7 @@
 Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.
 
 [![Alpha](https://img.shields.io/badge/status-alpha-orange)]()
-[![Version](https://img.shields.io/badge/version-0.2.7-blue)]()
+[![Version](https://img.shields.io/badge/version-0.2.8-blue)]()
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 **[Main Repository](https://github.com/AxmeAI/axme-code)** · **[Website](https://code.axme.ai)** · **[Issues](https://github.com/AxmeAI/axme-code/issues)**


### PR DESCRIPTION
## Summary

Patch release **v0.2.8** containing three bug fixes already merged on `main`:

| Backlog | PR | What |
|---|---|---|
| **B-006** | #105 | Audit worker `fileURLToPath(undefined)` crash on every session close |
| **B-007** | #106 | Telemetry classifier extended + `category`/`fatal` on failed audits |
| **B-008** | #107 | `#!axme` regex stops swallowing the closing quote of `-m "..."` |

## What ships

### Files bumped
- `package.json` — `0.2.7` → `0.2.8`
- `.claude-plugin/plugin.json` — `0.2.7` → `0.2.8`
- `templates/plugin-README.md` — version badge

### CHANGELOG.md
New `[0.2.8] - 2026-04-14` section with full notes per fix.

## Verification

- `npm test` — **489 / 489 pass**
- `npx tsc --noEmit` — clean
- `npm run build` — clean
- All three version files synchronized

## Release flow after merge

1. Merge this PR into `main`.
2. Tag and push (manual, agent cannot tag per D-024):
   ```bash
   git checkout main && git pull
   git tag v0.2.8
   git push origin v0.2.8
   ```
3. `release-binary.yml` auto-runs the chained jobs:
   - `build` — 4-platform matrix (linux-x64, linux-arm64, darwin-x64, darwin-arm64) → standalone bundles
   - `release` — creates GitHub Release with artifacts
   - `publish-npm` — `npm publish @axme/code@0.2.8` (gated on lint+test)
   - `sync-plugin-repo` — pushes plugin bundle to `AxmeAI/axme-code-plugin`
4. Update local install (closes the active stream of `audit_complete=failed` events on the dev mid):
   ```bash
   axme-code update      # or: curl -fsSL .../install.sh | bash
   ```

## Verification post-release

- [ ] `npm view @axme/code version` shows `0.2.8`
- [ ] GitHub Release page shows 4 platform binaries
- [ ] `axme-code-plugin` repo received fresh `sync: v0.2.8` commit
- [ ] After local update + one Claude Code session close, `.axme-code/audit-worker-logs/*` shows success (no `fileURLToPath` error), session `meta.json` `auditStatus = done`
- [ ] After 24h: telemetry `audit_complete outcome=failed error_class=unknown` count from any v0.2.8 mid drops to 0; new failures (if any) classify into `node_invalid_arg` / `type_error` / `module_not_found` / etc., not `unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
