### PR TITLE
release: v0.2.9 (auth mode + findClaudePath fallback + dep patches)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axme-code",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "(Alpha) Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.",
   "author": {
     "name": "AXME AI",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.2.9] - 2026-04-17
+
+### Added
+- **User-selectable auth mode** (#109): `axme-code setup` now detects both Claude subscription (OAuth) and `ANTHROPIC_API_KEY` in env. If both exist, prompts the user to choose. Choice persisted in `~/.config/axme-code/auth.yaml`. When `mode=subscription`, `ANTHROPIC_API_KEY` is deleted from subprocess env so Claude Code uses OAuth instead of hitting a zero-balance API key. New commands: `axme-code auth` (interactive), `axme-code auth status`, `axme-code auth use subscription|api_key`. All subprocesses (scanners, session-auditor, memory-extractor) go through the unified `buildAgentEnv()`.
+
+### Fixed
+- **`findClaudePath()` fallback for users without `claude` in PATH** (B-009, #110): v0.2.8 fixed B-006 by passing `pathToClaudeCodeExecutable`, but `findClaudePath()` used only `which claude` — new users with nvm-managed or non-global Claude installs still hit the original `fileURLToPath(undefined)` crash. Resolution now tries 5 sources in order: `AXME_CLAUDE_EXECUTABLE` env var, `CLAUDE_CODE_ENTRYPOINT` env var, `which claude`, standard install paths (`~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, `/usr/bin`), and nvm glob (`~/.nvm/versions/node/*/bin/claude`). Each candidate verified via `existsSync`. E2E tested with `claude` stripped from PATH — resolver found `/usr/local/bin/claude` via fallback.
+
+### Security
+- **Dependency patches** (#110): `hono` 4.12.12 → 4.12.14 (moderate, HTML injection in JSX SSR, via `@modelcontextprotocol/sdk`). `protobufjs` 7.5.4 → 7.5.5 (critical, arbitrary code execution, in `benchmarks/` only — not in product bundle). Both lockfile-only, 0 vulnerabilities remaining.
+
+### Tests
+- 8 new unit tests for `findClaudePath()` resolver: env var priority, non-existent path skip, step-1-beats-step-2, caching, cache reset, dev-machine smoke test.
+- Total test count: 489 → 511.
+
 ## [0.2.8] - 2026-04-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axme/code",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Persistent memory, decisions, and safety guardrails for Claude Code",
   "type": "module",
   "main": "./dist/server.js",

--- a/templates/plugin-README.md
+++ b/templates/plugin-README.md
@@ -5,7 +5,7 @@
 Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.
 
 [![Alpha](https://img.shields.io/badge/status-alpha-orange)]()
-[![Version](https://img.shields.io/badge/version-0.2.8-blue)]()
+[![Version](https://img.shields.io/badge/version-0.2.9-blue)]()
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 **[Main Repository](https://github.com/AxmeAI/axme-code)** · **[Website](https://code.axme.ai)** · **[Issues](https://github.com/AxmeAI/axme-code/issues)**


### PR DESCRIPTION
## Summary

Patch release **v0.2.9** with two features/fixes already merged on main:

- **PR #109** — User-selectable auth mode: `axme-code setup` detects subscription + API key, prompts choice, persists to `~/.config/axme-code/auth.yaml`. Fixes stale `ANTHROPIC_API_KEY` overriding subscription in subprocess env.
- **PR #110** — `findClaudePath()` 5-step resolver (B-009): env vars, `which`, standard paths, nvm glob. Fixes B-006 regression for users without global `claude` in PATH. Plus lockfile patches (hono 4.12.14, protobufjs 7.5.5).

## Files bumped

- `package.json` — 0.2.8 to 0.2.9
- `.claude-plugin/plugin.json` — 0.2.8 to 0.2.9
- `templates/plugin-README.md` — version badge
- `CHANGELOG.md` — new [0.2.9] section

## Verification

- `npm test` — **511/511 pass**
- `npm run build` — clean
- All 3 version files synchronized
- Plugin repo confirmed correctly synced at v0.2.8 — v0.2.9 will sync the same way

## After merge

```bash
git checkout main && git pull
git tag v0.2.9
git push origin v0.2.9
```

Workflow chain: build (4 platforms) -> GitHub Release -> npm publish -> plugin sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
