### PR TITLE
chore: sync package-lock.json version to 0.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axme/code",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axme/code",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",


### PR DESCRIPTION
Missed in release PR #111. Lockfile stayed at 0.2.8. One-line fix. Merge before tagging v0.2.9.