### PR TITLE
docs: remove false native Windows support claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Decisions enforce verification requirements: agent must run tests and show proof
 curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash
 ```
 
-Installs to `~/.local/bin/axme-code`. Supports Linux, macOS, and Windows (x64 and ARM64).
+Installs to `~/.local/bin/axme-code`. Supports Linux and macOS (x64 and ARM64). Native Windows is not yet supported.
 
 ### Setup
 

--- a/docs/TELEMETRY_TZ.md
+++ b/docs/TELEMETRY_TZ.md
@@ -56,7 +56,7 @@ The server **never** returns an error to the client — invalid events are silen
 
 - 64 hex chars (32 random bytes hex-encoded)
 - Generate **once** per install on first run, persist to disk
-- Storage location: `~/.local/share/axme-code/machine-id` (Linux/macOS), platform-equivalent on Windows
+- Storage location: `~/.local/share/axme-code/machine-id` (Linux/macOS)
 - File mode `0600`
 - **Must NOT** be derived from hardware (no MAC address, no CPU serial, no hostname). Use `crypto.randomBytes(32).toString('hex')`
 - If file exists, read it. If not, generate and write


### PR DESCRIPTION
## Summary

- README's Quick Start advertised Windows support (x64 and ARM64), but [install.sh:13-17](../blob/main/install.sh#L13-L17) rejects any OS other than `linux`/`darwin` and the release workflow builds no `windows-*` binary. Claim was demonstrably false.
- `docs/TELEMETRY_TZ.md` said machine-id storage was "platform-equivalent on Windows". Same issue — Windows isn't supported today.

Replaced both with honest "Linux and macOS" wording. Native Windows support is a separate future effort.

Related false claim in [AxmeAI/axme-code-site](https://github.com/AxmeAI/axme-code-site) (schema.org JSON-LD) is being fixed in a parallel PR.

## Test plan

- [x] `grep -n "[Ww]indows" README.md docs/` — no user-facing support claims remain (only the accurate `/proc` fallback comment in code)
- [x] install.sh / release-binary.yml unchanged — already consistent with doc (linux + darwin only)
- [ ] Preview README render on the PR page shows the updated line

🤖 Generated with [Claude Code](https://claude.com/claude-code)