### PR TITLE
fix: add --version flag and scanner preflight for missing claude CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,10 +20,15 @@ import { detectAuthOptions } from "./utils/auth-detect.js";
 import { authConfigPath, loadAuthConfig, saveAuthConfig } from "./utils/auth-config.js";
 import { formatDetectionBlock, hasAnyAuth, promptAuthChoice } from "./utils/auth-prompt.js";
 import type { AuthMode, WorkspaceInfo } from "./types.js";
-import { AXME_CODE_DIR } from "./types.js";
+import { AXME_CODE_DIR, AXME_CODE_VERSION } from "./types.js";
 
 const args = process.argv.slice(2);
 const command = args[0];
+
+if (command === "--version" || command === "-v") {
+  console.log(AXME_CODE_VERSION);
+  process.exit(0);
+}
 
 // --- CLAUDE.md templates ---
 

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -21,6 +21,7 @@ import { bundlesToDecisions, bundlesToMemories, bundlesToDeployChecklists, apply
 import { AXME_CODE_DIR, DEFAULT_PROJECT_CONFIG } from "../types.js";
 import { addCost, zeroCost, type CostInfo } from "../utils/cost-extractor.js";
 import { atomicWrite, removeFile } from "../storage/engine.js";
+import { findClaudePath } from "../utils/agent-options.js";
 import yaml from "js-yaml";
 
 export interface InitResult {
@@ -142,7 +143,6 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
   // --- LLM scanners in PARALLEL ---
   const log = opts?.onProgress ?? (() => {});
   const projectName = projectPath.split("/").pop();
-  log(`  [${projectName}] LLM scanning (oracle + decisions + safety + deploy)...`);
 
   let oracleLlm = false;
   let oracleFiles = 0;
@@ -150,31 +150,45 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
   let safetyLlm = false;
   let safetySummary = "";
 
-  const scanners = await Promise.allSettled([
-    // Oracle scan
-    (async () => {
-      if (oracleExists(projectPath)) return { type: "oracle" as const, skipped: true };
-      const { runOracleScan } = await import("../agents/scanners/oracle.js");
-      return { type: "oracle" as const, result: await runOracleScan({ projectPath, workspaceMode: opts?.workspaceMode }) };
-    })(),
-    // Decision scan — pass existing decisions (from presets) so scanner skips same-topic
-    (async () => {
-      const { runDecisionScan } = await import("../agents/scanners/decision.js");
-      const existing = listDecisions(projectPath);
-      return { type: "decision" as const, result: await runDecisionScan({ projectPath, existingDecisions: existing }) };
-    })(),
-    // Safety scan
-    (async () => {
-      if (safetyExists(projectPath)) return { type: "safety" as const, skipped: true };
-      const { runSafetyScan } = await import("../agents/scanners/safety.js");
-      return { type: "safety" as const, result: await runSafetyScan({ projectPath }) };
-    })(),
-    // Deploy scan
-    (async () => {
-      const { runDeployScan } = await import("../agents/scanners/deploy.js");
-      return { type: "deploy" as const, result: await runDeployScan({ projectPath }) };
-    })(),
-  ]);
+  // Pre-flight: require the `claude` CLI to be installed. Without it the Agent
+  // SDK bundled inside us crashes on `fileURLToPath(undefined)` before it can
+  // reach the user's OAuth/API key. Skip cleanly and surface a friendly error
+  // rather than leaking the SDK stack trace.
+  const claudePath = findClaudePath();
+  const scanners = claudePath
+    ? await (async () => {
+        log(`  [${projectName}] LLM scanning (oracle + decisions + safety + deploy)...`);
+        return Promise.allSettled([
+          // Oracle scan
+          (async () => {
+            if (oracleExists(projectPath)) return { type: "oracle" as const, skipped: true };
+            const { runOracleScan } = await import("../agents/scanners/oracle.js");
+            return { type: "oracle" as const, result: await runOracleScan({ projectPath, workspaceMode: opts?.workspaceMode }) };
+          })(),
+          // Decision scan — pass existing decisions (from presets) so scanner skips same-topic
+          (async () => {
+            const { runDecisionScan } = await import("../agents/scanners/decision.js");
+            const existing = listDecisions(projectPath);
+            return { type: "decision" as const, result: await runDecisionScan({ projectPath, existingDecisions: existing }) };
+          })(),
+          // Safety scan
+          (async () => {
+            if (safetyExists(projectPath)) return { type: "safety" as const, skipped: true };
+            const { runSafetyScan } = await import("../agents/scanners/safety.js");
+            return { type: "safety" as const, result: await runSafetyScan({ projectPath }) };
+          })(),
+          // Deploy scan
+          (async () => {
+            const { runDeployScan } = await import("../agents/scanners/deploy.js");
+            return { type: "deploy" as const, result: await runDeployScan({ projectPath }) };
+          })(),
+        ]);
+      })()
+    : [];
+  if (!claudePath) {
+    log(`  [${projectName}] Claude Code CLI not found on PATH — skipping LLM scanners (install with: npm install -g @anthropic-ai/claude-code)`);
+    errors.push("Claude Code CLI not installed — LLM scanners skipped, using deterministic fallback");
+  }
 
   // Process results
   log(`  [${projectName}] Scanners complete, processing results...`);


### PR DESCRIPTION
## Summary

Two user-visible bugs found during WSL2 E2E testing.

### 1. `axme-code --version` returned "Unknown command"

The README Quick Start tells users to run `axme-code` right after install. The natural first command — `axme-code --version` — dumped the usage text. Added `--version` / `-v` handler at the top of `src/cli.ts` that prints `AXME_CODE_VERSION` and exits 0.

### 2. LLM scanner leaked `TypeError: path must be string` stack trace when `claude` CLI not installed

When `axme-code setup` runs without the `claude` CLI on PATH (e.g. fresh WSL install that only has our binary), the Agent SDK bundled inside us crashes on `fileURLToPath(undefined)` in each of the 4 scanners, leaking the stack trace 3x to the user through `errors.push`. Deterministic fallback already runs, so `.axme-code/` is unaffected — the fix is purely UX.

Added a pre-flight `findClaudePath()` check in `src/tools/init.ts` before `Promise.allSettled`. If `claude` is missing, log a friendly message with the install command and skip scanner invocation entirely. Downstream processing loop iterates the empty array and the existing deterministic-oracle fallback block kicks in.

## Test plan

- [x] `node dist/axme-code.js --version` prints `0.2.9`, exits 0
- [x] `node dist/axme-code.js -v` prints `0.2.9`, exits 0
- [x] `node dist/axme-code.js --unknown-flag` still prints "Unknown command" + usage (regression guard)
- [x] `node dist/axme-code.js status` still works
- [x] `npm test` 511/511 pass
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean

Not added: new unit tests. The `--version` path is trivial and covered manually; the preflight branch is defensive against an SDK interaction that's hard to mock cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
