### PR TITLE
fix: bump session lock wait to 3s so slow I/O does not race duplicates

### DIFF
--- a/src/storage/sessions.ts
+++ b/src/storage/sessions.ts
@@ -487,7 +487,13 @@ export function clearLegacyActiveSession(projectPath: string): void {
  * Stale lock (>5s) auto-cleaned to handle crashed lock holders.
  */
 const LOCK_STALE_MS = 5_000;
-const LOCK_WAIT_MS = 500;
+// Bounded by the PreToolUse hook's 5-second timeout in .claude/settings.json —
+// leave ~2s headroom for the rest of the hook work after the lock is released.
+// The previous 500ms was too tight on slow I/O (WSL2, busy SSDs) where a
+// lock-holder could still be writing its mapping when waiters timed out and
+// each then created a duplicate session. LOCK_STALE_MS > LOCK_WAIT_MS keeps
+// the stale-lock recovery path independent of normal contention.
+const LOCK_WAIT_MS = 3_000;
 const LOCK_POLL_MS = 50;
 
 // Exported for testing


### PR DESCRIPTION
## Summary

The concurrency test `test/audit-dedup.test.ts` → `ensureAxmeSessionForClaude - parallel processes (E2E)` → `5 parallel processes create exactly 1 session` was intermittently failing on WSL2 (510 / 511) during the WSL2 E2E verification session. Root cause: `LOCK_WAIT_MS = 500` is too short for slow-I/O systems — five `npx tsx` workers contend for the per-Claude-session file lock, the first one acquires it but is still writing its mapping when the other four time out at 500 ms, and each of those then creates its own AXME session.

Raised `LOCK_WAIT_MS` to 3000 ms.

- Still bounded by the 5-second `PreToolUse` hook timeout in `.claude/settings.json` (leaves 2 s for the rest of the hook).
- Still strictly less than `LOCK_STALE_MS = 5000`, so stale-lock recovery semantics are unchanged.
- No change to the lock primitive, polling interval, or release path.

## Test plan

- [x] Targeted run of the flaky test 10x on Linux — 11/11 each, all green.
- [x] Full `npm test` — 511/511 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean.

## Context

Surfaced while running `npm test` inside WSL2 Ubuntu 22.04 on an Azure Win11 D2s_v5 VM as part of step 2 of the native-Windows-support rollout. The same test passes consistently on native Linux because native I/O completes well under 500 ms. See `wsl2-full-e2e-verified-including-detached-audit-worker-2026-04-17` memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
