### PR TITLE
docs: note WSL2 support with install-inside-WSL requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Decisions enforce verification requirements: agent must run tests and show proof
 curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash
 ```
 
-Installs to `~/.local/bin/axme-code`. Supports Linux and macOS (x64 and ARM64). Native Windows is not yet supported.
+Installs to `~/.local/bin/axme-code`. Supports Linux and macOS (x64 and ARM64).
+
+**Windows via WSL2** is supported. Install a WSL2 distro (`wsl --install -d Ubuntu-22.04`), then install both Claude Code and axme-code **inside** your WSL distro — not on the Windows host. Native Windows is not yet supported.
 
 ### Setup
 


### PR DESCRIPTION
## Summary

Adds an explicit "Windows via WSL2" note to the Quick Start in [README.md](README.md), after the Linux/macOS install line. End-to-end verified on 2026-04-17 on an Azure Win11 Pro 24H2 D2s_v5 VM running WSL2 Ubuntu 22.04 (kernel 6.6.87):

- `install.sh` downloads `linux-x64` binary correctly
- `axme-code setup` with real Claude subscription OAuth — 9 LLM-extracted decisions + 13 presets, $0.31, 115s, zero errors
- MCP server stdio `initialize` handshake returns proper `serverInfo`
- `PreToolUse` hook blocks `rm -rf /` (permissionDecision: deny), allows `ls`
- Full `claude --print` session — `SessionEnd` hook fires, detached audit worker spawns and completes with `audit_complete` written to `worklog.jsonl` (cost $0.086)
- 510 / 511 unit tests pass in WSL kernel (the one flaky test was fixed in #115)

## Critical caveat captured in the README

Claude Code must be installed **inside** the WSL distro, not on the Windows host. A Linux binary in WSL cannot be spawned over stdio by a Windows-side Claude Code — users who install Claude Code natively on Windows and try to point it at a WSL-side axme-code will hit this silently. The README now says this in the same sentence so it is impossible to miss.

## What's NOT claimed yet

Native Windows (cmd.exe / PowerShell, no WSL) is still explicitly called out as not supported. That's the next phase.

## Test plan

- [x] Read through the Quick Start — wording reads naturally inline with the existing install-sh line
- [x] No code changes, no tests affected
- [x] Site SEO (schema.org JSON-LD in `axme-code-site`) stays at "Linux, macOS" for now — can extend in a follow-up if we want Windows searches to find us

🤖 Generated with [Claude Code](https://claude.com/claude-code)
