### PR TITLE
docs(README): add Claude Code plugin install as recommended path

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,7 @@ claude plugin marketplace add anthropics/claude-plugins-community
 claude plugin install axme-code@claude-community
 ```
 
-Works on Linux, macOS, and Windows — anywhere Claude Code runs. The plugin ships with the MCP server, safety hooks, and CLI bundled together; no separate binary to install.
-
-On first use in a project, just ask the agent to call `axme_context` — the plugin auto-initializes the knowledge base on that session.
+The plugin ships with the MCP server, safety hooks, and CLI bundled together; no separate binary to install. On first use in a project, just ask the agent to call `axme_context` — the plugin auto-initializes the knowledge base on that session.
 
 ### Option 2: Standalone binary
 
@@ -108,7 +106,9 @@ Install the CLI system-wide (useful if you want to run `axme-code` outside Claud
 curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash
 ```
 
-Installs to `~/.local/bin/axme-code`. Supports Linux and macOS (x64 and ARM64). **Windows via WSL2** is supported — run the Linux one-liner inside your WSL distro and install Claude Code inside WSL too. Native Windows is not yet supported via this path (the plugin above works on Windows natively).
+Installs to `~/.local/bin/axme-code`. Supports Linux and macOS (x64 and ARM64).
+
+**Windows via WSL2** is supported. Install a WSL2 distro (`wsl --install -d Ubuntu-22.04`), then install both Claude Code and axme-code **inside** your WSL distro — not on the Windows host. Native Windows is not yet supported.
 
 Then in each project:
 

--- a/README.md
+++ b/README.md
@@ -80,15 +80,37 @@ Decisions enforce verification requirements: agent must run tests and show proof
 
 **Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (CLI or VS Code extension).**
 
+### Option 1: Claude Code plugin (recommended)
+
+In Claude Code, run:
+
+```
+/plugin marketplace add anthropics/claude-plugins-community
+/plugin install axme-code@claude-community
+```
+
+Or from the terminal:
+
+```bash
+claude plugin marketplace add anthropics/claude-plugins-community
+claude plugin install axme-code@claude-community
+```
+
+Works on Linux, macOS, and Windows — anywhere Claude Code runs. The plugin ships with the MCP server, safety hooks, and CLI bundled together; no separate binary to install.
+
+On first use in a project, just ask the agent to call `axme_context` — the plugin auto-initializes the knowledge base on that session.
+
+### Option 2: Standalone binary
+
+Install the CLI system-wide (useful if you want to run `axme-code` outside Claude Code, e.g. for scripting):
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash
 ```
 
-Installs to `~/.local/bin/axme-code`. Supports Linux and macOS (x64 and ARM64).
+Installs to `~/.local/bin/axme-code`. Supports Linux and macOS (x64 and ARM64). **Windows via WSL2** is supported — run the Linux one-liner inside your WSL distro and install Claude Code inside WSL too. Native Windows is not yet supported via this path (the plugin above works on Windows natively).
 
-**Windows via WSL2** is supported. Install a WSL2 distro (`wsl --install -d Ubuntu-22.04`), then install both Claude Code and axme-code **inside** your WSL distro — not on the Windows host. Native Windows is not yet supported.
-
-### Setup
+Then in each project:
 
 ```bash
 cd your-project          # or workspace root for multi-repo


### PR DESCRIPTION
## Summary

axme-code is now listed in `anthropics/claude-plugins-community` — the auto-populated Claude Code community marketplace (1636 plugins, separate from the curated `claude-plugins-official`). Users can install via the plugin system without downloading a binary. This PR adds the plugin install as the recommended path in the Quick Start.

## Changes

- **Option 1 (recommended)**: `/plugin install axme-code@claude-community` — bundles MCP server, hooks, and CLI; works on Linux, macOS, and Windows natively (anywhere Claude Code runs). Also shows the CLI-equivalent commands (`claude plugin marketplace add ...`).
- **Option 2**: existing `install.sh` binary path kept intact for standalone/scripting/non-Claude-Code use cases. Windows note clarified — binary path still requires WSL2, but the plugin path works on native Windows.

## Why a separate community marketplace?

Submission form at `claude.ai/settings/plugins/submit` routes approved plugins to `anthropics/claude-plugins-community` (auto-populated, 1636 plugins). The curated `-official` catalog (144 plugins, shown on claude.com/plugins) is manually selected by Anthropic. Most third-party plugins live in community; this PR tells users how to install from there.

Known gap on Anthropic's side: `claude.com/plugins` web catalog and the default-added `-official` marketplace don't surface community plugins yet, which is why users need to add the community marketplace explicitly (see [issue #1272](https://github.com/anthropics/claude-plugins-official/issues/1272)).

## Test plan

- [x] Verified install end-to-end on Linux:
  ```
  $ claude plugin install axme-code@claude-community
  ✔ Successfully installed plugin: axme-code@claude-community (scope: user)
  ```
  `claude plugin list` shows `axme-code@claude-community` v0.2.9, enabled.
- [x] Only README.md touched, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
