### PR TITLE
Add glama.json for Glama directory claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "George-iam"
+  ]
+}


### PR DESCRIPTION
Adds `glama.json` to repo root so we can claim the AXME Code listing on https://glama.ai/mcp/servers/AxmeAI/axme-code

This is the documented prerequisite for claiming an organization-owned MCP server on Glama (https://glama.ai/mcp/schemas/server.json). Required before adding the Dockerfile that lets Glama validate the server starts and responds to introspection.

Maintainer listed: George-iam (the GitHub account that will claim and admin the listing).

Why we are claiming the listing:
- Glama validation is now a hard requirement for merge in punkpeye/awesome-mcp-servers (85.7K stars), where AXME Code PR #5510 is open: https://github.com/punkpeye/awesome-mcp-servers/pull/5510
- Lets us update the description, configure Docker build instructions, and receive review notifications

After merge, next steps (manual on Glama side):
1. Click 'Login with GitHub to claim' on the Glama listing
2. Add the Dockerfile in admin (verified locally to pass MCP introspection)
3. Wait for green checks at /score
4. Add the Glama badge to the punkpeye PR description