### PR TITLE
Add Dockerfile for Glama MCP directory validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash
+
+ENV PATH="/root/.local/bin:${PATH}"
+ENV AXME_TELEMETRY_DISABLED=1
+
+WORKDIR /workspace
+
+ENTRYPOINT ["axme-code", "serve"]


### PR DESCRIPTION
Adds a minimal `Dockerfile` to repo root so Glama can validate AXME Code on https://glama.ai/mcp/servers/AxmeAI/axme-code

## Why

Glama validation is the gating requirement for merge in punkpeye/awesome-mcp-servers PR #5510 (85.7K stars). Glama also hosts a containerized version of any claimed server and exposes it via SSE / Streamable HTTP, which gives non-Claude-Code MCP clients (Cursor, VS Code, etc.) a way to use AXME Code through Glama's gateway.

Their UI admin/dockerfile page can be flaky for fresh claims; placing the file in repo root is the more reliable path (Glama auto-detects it on next refetch).

## What it does

The Dockerfile downloads and runs the standard `install.sh` (the same path documented in README.md), then runs `axme-code serve` as ENTRYPOINT.

```dockerfile
FROM node:20-slim
RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
RUN curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash
ENV PATH="/root/.local/bin:${PATH}"
ENV AXME_TELEMETRY_DISABLED=1
WORKDIR /workspace
ENTRYPOINT ["axme-code", "serve"]
```

`AXME_TELEMETRY_DISABLED=1` is set because Glama containers are not real user installs.

## Verification (local)

Built and tested locally:

```
$ docker build -t axme-code-glama-test:latest .
Successfully built ...

$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"glama-validator","version":"1.0.0"}}}' | docker run -i --rm axme-code-glama-test:latest

{"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"axme","version":"0.1.0"},"instructions":"AXME Code MCP server is active..."},"jsonrpc":"2.0","id":1}
AXME cleanup (stdin-end): 0 owned, 0 to audit, 0 deduped
```

Server starts cleanly, responds to MCP initialize, exposes tools capability with `listChanged: true`, exits cleanly on stdin close. Exactly what Glama introspection check expects.

## Scope

Pure ops/distribution addition. No source changes. Distribution model stays binary-only per D-114; this Dockerfile is purely for Glama hosting.