### PR TITLE
docs(README): add 'Works With Any MCP Client' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,44 @@ AXME Code complements CLAUDE.md — it reads your existing CLAUDE.md during setu
 
 ---
 
+## Works With Any MCP Client
+
+AXME Code is a [stdio MCP server](https://modelcontextprotocol.io/) — every MCP-compatible AI coding assistant gets the full set of `axme_*` tools (knowledge base read/write, safety queries, status, worklog).
+
+| Client | MCP Tools | Safety Hooks | Auto Auditor |
+|---|---|---|---|
+| **Claude Code** (CLI / VS Code) | ✅ Full | ✅ Full | ✅ Yes |
+| **Cursor** | ✅ Full | ❌ | ❌ |
+| **Windsurf** | ✅ Full | ❌ | ❌ |
+| **Cline** (VS Code) | ✅ Full | ❌ | ❌ |
+| **Claude Desktop** | ✅ Full | ❌ | ❌ |
+| **Any other MCP client** | ✅ Full | ❌ | ❌ |
+
+The MCP server entry is identical in every client:
+
+```json
+{
+  "mcpServers": {
+    "axme": {
+      "command": "axme-code",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+Just place it in your client's MCP config file:
+- **Cursor:** `~/.cursor/mcp.json` or `.cursor/mcp.json` (per-project)
+- **Windsurf:** `~/.codeium/windsurf/mcp_config.json`
+- **Cline:** VS Code Settings → Cline MCP → `cline_mcp_settings.json`
+- **Claude Desktop:** `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or equivalent
+
+Pre-execution safety hooks, the post-tool-use file tracker, and the background session auditor are Claude Code-specific (they require Claude Code's hook system). In other clients, the agent must call AXME tools explicitly — same knowledge base, same `.axme-code/` storage, just no automatic enforcement layer.
+
+See [docs/MULTI_CLIENT.md](docs/MULTI_CLIENT.md) for full per-client setup, hook workarounds, and concurrent-client semantics.
+
+---
+
 ## Comparison
 
 | | AXME Code | MemPalace | Mastra | Zep | Mem0 | Supermemory |


### PR DESCRIPTION
## Summary

Surfaces multi-client support (Cursor / Windsurf / Cline / Claude Desktop / any MCP client) in the main README. Previously this was documented only in `docs/MULTI_CLIENT.md` (added Apr 14 in PR #103) — first-time visitors to the README didn't see that AXME Code works outside Claude Code.

Adds a `## Works With Any MCP Client` section between "Why Not Just CLAUDE.md?" and "Comparison" with:

- Compatibility matrix (5 clients + generic, columns: MCP Tools / Safety Hooks / Auto Auditor)
- The universal MCP server entry snippet (`axme-code serve` works for everyone)
- Per-client config-file paths (Cursor / Windsurf / Cline / Claude Desktop)
- Note that hooks are Claude Code-specific while MCP tools work everywhere
- Link to `docs/MULTI_CLIENT.md` for the deeper per-client guide

## Why now

This is **B-005 Phase 1** — multi-client docs surfacing. Phase 2 (semantic search MCP tools) lands next as a separate PR; together they ship as v0.5.0.

## Test plan

- [x] Rendered preview reads correctly (markdown structure, table, code block, links)
- [x] Link to `docs/MULTI_CLIENT.md` resolves
- [ ] Reviewer eyes that the matrix is accurate and the MCP server snippet matches the canonical form

## Scope

Pure docs change. Zero code, zero tests, zero behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)