### PR TITLE
docs(cli): include config get/set + reindex + --version in usage()

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -320,17 +320,29 @@ function usage(): void {
   console.log(`AXME Code - Persistent memory, decisions, and safety guardrails for Claude Code
 
 Usage:
-  axme-code setup [path] [--force]         Initialize project (LLM scan + .mcp.json + CLAUDE.md)
-  axme-code serve                         Start MCP server (stdio transport)
-  axme-code status [path]                 Show project status
-  axme-code auth                          Re-detect and choose auth mode (subscription/api_key)
-  axme-code auth status                   Show current auth mode + detected options
-  axme-code auth use <subscription|api_key>  Set auth mode non-interactively
-  axme-code cleanup legacy-artifacts [--dry-run]  Remove pre-PR#7 sessions/logs
-  axme-code cleanup decisions-normalize [--dry-run]  Add status:active to decisions
-  axme-code audit-kb [path] [--all-repos]             KB audit: dedup, conflicts, compaction
-  axme-code stats [path]                  Worklog statistics (sessions, costs, safety blocks)
-  axme-code help                          Show this help
+  axme-code setup [path] [--force]              Initialize project (LLM scan + .mcp.json + CLAUDE.md)
+  axme-code serve                               Start MCP server (stdio transport)
+  axme-code status [path]                       Show project status
+  axme-code --version | -v                      Print the installed version
+
+  axme-code config get <key>                    Read a value from .axme-code/config.yaml
+                                                (keys: context.mode, model, auditor_model, review_enabled)
+  axme-code config set context.mode <full|search>
+                                                Switch context-loading mode. 'search' installs the
+                                                semantic-search runtime (~100MB, one-time) and
+                                                builds an embeddings index of every memory + decision.
+                                                Rolls back to 'full' on install or reindex failure.
+  axme-code reindex [path]                      Force a full re-embed of all memories + decisions
+                                                into .axme-code/_index/embeddings.json (search mode only)
+
+  axme-code auth                                Re-detect and choose auth mode (subscription/api_key)
+  axme-code auth status                         Show current auth mode + detected options
+  axme-code auth use <subscription|api_key>     Set auth mode non-interactively
+  axme-code cleanup legacy-artifacts [--dry-run]   Remove pre-PR#7 sessions/logs
+  axme-code cleanup decisions-normalize [--dry-run]   Add status:active to decisions
+  axme-code audit-kb [path] [--all-repos]       KB audit: dedup, conflicts, compaction
+  axme-code stats [path]                        Worklog statistics (sessions, costs, safety blocks)
+  axme-code help                                Show this help
 
 After setup, run 'claude' as usual. AXME tools are available automatically.`);
 }


### PR DESCRIPTION
## Summary

The commands that shipped in v0.5.0 — `axme-code config get/set context.mode`, `axme-code reindex`, plus the `--version` / `-v` flag — were present in the implementation but missing from the `axme-code help` output. Users running v0.5.0 still see the old v0.2.x command list when they look for the new search-mode opt-in.

This PR updates `usage()` in `src/cli.ts` to include all four new entries, with a brief description of what `config set context.mode search` actually does (install runtime, build embeddings index, atomic rollback on failure) so users don't have to leave the help to find that out.

Discovered when the user asked "почему её нет в axme-code help?" right after running v0.5.0.

## Scope

Pure docs change — single function (`usage()`) updated, no behaviour change, no test impact. Will land in the next release's CHANGELOG (rolled into v0.5.1 / v0.6.0 / whatever ships next).

## Test plan

- [x] `npm test` — 536/536 still pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `node dist/axme-code.js help` shows the new entries
- [ ] CI 3-OS matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)