### PR TITLE
fix(install): shell-aware PATH instruction (bash/zsh/fish/tcsh/csh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`install.sh` now detects the user's login shell and prints PATH-add instructions in the right syntax for that shell.** Previously `install.sh` printed only the `export PATH=...` form (bash/zsh syntax) regardless of the actual shell, leaving tcsh / csh / fish users with a non-working snippet — and `~/.local/bin` is not on PATH by default for tcsh, so those users effectively could not run `axme-code` after install. Detection uses `$SHELL` first (most reliable) and falls back to `getent passwd` for the login shell. Coverage: bash → `~/.bashrc`, zsh → `~/.zshrc`, fish → `~/.config/fish/config.fish` with `set -gx`, tcsh → `~/.tcshrc` with `setenv`, csh → `~/.cshrc` with `setenv`. Unknown shells get a fallback printout listing all four forms. The script does NOT auto-edit any rc file — the user runs the printed command themselves so they can audit the change. Same model as `deno`, `starship`, `nvm`. (`install.ps1` is unaffected — Windows installer already auto-writes the User PATH via `[Environment]::SetEnvironmentVariable`.)
+- **`install.sh` is now safely sourceable.** The bottom-of-file `main "$@"` is gated behind a `BASH_SOURCE[0] = $0` guard so `source install.sh` no longer triggers a real download + install side effect. Lets the new helper functions (`detect_shell`, `print_path_instruction`) be unit-tested without touching the live binary.
+
 ### Changed
 
 - **`axme_decisions` and `axme_memories` now adapt their output to `config.context.mode`.** In `full` mode (default) both tools return full bodies grouped by enforce / type, exactly as before. In `search` mode they return a compact catalog (id/slug + title + 1-line description, ≤200 chars) and instruct the agent to fetch full bodies via `axme_get_decision` / `axme_get_memory` / `axme_search_kb`. This closes a regression in v0.5.0 where the catalog was loaded by `axme_context` but a subsequent agent call to `axme_decisions` or `axme_memories` would silently re-load every body, defeating search mode's ~10× token saving. `axme_oracle` is unaffected — it always returns the full stack/structure/patterns/glossary because those are connected documents, not catalog entries.

--- a/install.sh
+++ b/install.sh
@@ -82,9 +82,7 @@ main() {
   echo "Installed axme-code to ${INSTALL_DIR}/axme-code"
 
   if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
-    echo ""
-    echo "Add to your PATH:"
-    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    print_path_instruction "$INSTALL_DIR"
   fi
 
   echo ""
@@ -93,4 +91,84 @@ main() {
   echo "  axme-code setup"
 }
 
-main "$@"
+# Detect the user's login shell from $SHELL (most reliable across distros);
+# fallback to getent passwd. Returns the shell base name (bash/zsh/fish/tcsh/
+# csh/...) or "unknown" so the caller can print a generic hint.
+detect_shell() {
+  local shell_path=""
+  if [ -n "${SHELL:-}" ]; then
+    shell_path="$SHELL"
+  elif command -v getent &>/dev/null && [ -n "${USER:-}" ]; then
+    shell_path="$(getent passwd "$USER" 2>/dev/null | cut -d: -f7)"
+  fi
+  case "$(basename "${shell_path:-unknown}")" in
+    bash)  echo "bash" ;;
+    zsh)   echo "zsh" ;;
+    fish)  echo "fish" ;;
+    tcsh)  echo "tcsh" ;;
+    csh)   echo "csh" ;;
+    *)     echo "unknown" ;;
+  esac
+}
+
+# Print shell-aware instructions for adding $1 to PATH. Covers bash/zsh/fish/
+# tcsh/csh; unknown shells get the bash/zsh form as a safe default plus a
+# pointer to manually consult the shell's docs. We do NOT auto-edit any rc
+# file — the user runs the command themselves so they can audit the change.
+print_path_instruction() {
+  local dir="$1" shell rc add_line
+  shell="$(detect_shell)"
+  echo ""
+  echo "${dir} is not on your PATH."
+  case "$shell" in
+    bash)
+      rc="$HOME/.bashrc"
+      add_line="export PATH=\"${dir}:\$PATH\""
+      echo "Detected shell: bash. Add it with:"
+      echo "  echo '${add_line}' >> ${rc}"
+      echo "  source ${rc}"
+      ;;
+    zsh)
+      rc="$HOME/.zshrc"
+      add_line="export PATH=\"${dir}:\$PATH\""
+      echo "Detected shell: zsh. Add it with:"
+      echo "  echo '${add_line}' >> ${rc}"
+      echo "  source ${rc}"
+      ;;
+    fish)
+      rc="$HOME/.config/fish/config.fish"
+      add_line="set -gx PATH ${dir} \$PATH"
+      echo "Detected shell: fish. Add it with:"
+      echo "  mkdir -p $(dirname "$rc") && echo '${add_line}' >> ${rc}"
+      echo "  source ${rc}"
+      ;;
+    tcsh)
+      rc="$HOME/.tcshrc"
+      add_line="setenv PATH ${dir}:\$PATH"
+      echo "Detected shell: tcsh. Add it with:"
+      echo "  echo '${add_line}' >> ${rc}"
+      echo "  source ${rc}"
+      ;;
+    csh)
+      rc="$HOME/.cshrc"
+      add_line="setenv PATH ${dir}:\$PATH"
+      echo "Detected shell: csh. Add it with:"
+      echo "  echo '${add_line}' >> ${rc}"
+      echo "  source ${rc}"
+      ;;
+    *)
+      echo "Could not detect your shell (\$SHELL=${SHELL:-unset}). Pick the form that matches:"
+      echo "  bash/zsh:  export PATH=\"${dir}:\$PATH\"      (in ~/.bashrc or ~/.zshrc)"
+      echo "  fish:      set -gx PATH ${dir} \$PATH         (in ~/.config/fish/config.fish)"
+      echo "  tcsh/csh:  setenv PATH ${dir}:\$PATH          (in ~/.tcshrc or ~/.cshrc)"
+      echo "Then open a new terminal or 'source' the rc file."
+      ;;
+  esac
+}
+
+# Only run main when executed directly, not when sourced. Lets us source
+# the script for unit testing of detect_shell / print_path_instruction
+# without triggering a real download+install.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary

`install.sh` previously printed only the bash/zsh `export PATH=...` form regardless of the user's shell. On tcsh that snippet is invalid syntax, AND `~/.local/bin` is not on PATH by default for tcsh (most distros add it via `~/.profile`, which tcsh doesn't read), so tcsh users could not run `axme-code` after install. Reported by user on a tcsh machine today.

## Changes

- Detect login shell from `$SHELL` (fallback: `getent passwd`).
- Print the right syntax + rc-file for each shell:
  - bash → `~/.bashrc` `export PATH="...:$PATH"`
  - zsh → `~/.zshrc` `export PATH=...`
  - fish → `~/.config/fish/config.fish` `set -gx PATH ... $PATH`
  - tcsh → `~/.tcshrc` `setenv PATH ...:$PATH`
  - csh → `~/.cshrc` `setenv PATH ...:$PATH`
- Unknown shell → fallback listing all four forms.
- **No auto-edit of rc files.** User runs the printed command. Same model as deno / starship / nvm.
- `install.ps1` unchanged — Windows installer already auto-writes User PATH via `[Environment]::SetEnvironmentVariable`.

## Bonus

`main "$@"` now gated behind `BASH_SOURCE[0] = $0` so `source install.sh` no longer fires a real download + install. Lets the helper functions be unit-tested without touching the live binary. (Caught while smoke-testing this very PR — accidentally re-ran an install during a sourced test.)

## Test plan

- [x] `bash -n install.sh` clean.
- [x] All 6 shell branches smoke-tested via `SHELL=... bash -c 'source install.sh; print_path_instruction /tmp/x'` — each prints correct syntax + rc-file.
- [x] Sourcing guard verified — sourcing the file no longer triggers main.

## CHANGELOG

Added under `[Unreleased]`. No version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)