### PR TITLE
ci: build darwin-x64 on macos-latest runner + bump version 0.1.0

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -38,7 +38,7 @@ jobs:
             binary_name: axme-code-linux-arm64
             extension_bin: axme-code
           - target: darwin-x64
-            runner: macos-13
+            runner: macos-latest
             binary_name: axme-code-darwin-x64
             extension_bin: axme-code
           - target: darwin-arm64

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "axme-code",
   "displayName": "AXME Code",
   "description": "Persistent memory, decisions, and safety guardrails for Cursor, GitHub Copilot, Cline, Continue, Roo Code, Windsurf, and VS Code chat agents",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "publisher": "AxmeAI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Two changes for the first real marketplace publish:

**1. CI workflow fix** — every `publish-extension` run since the v0.0.3 tag push got stuck on the `darwin-x64` build job. It requested a `macos-13` Intel Mac runner that GitHub Actions never allocated. Six runs across the past hour show darwin-x64 with status=queued, runner_name=null, never started. Apple deprecated Intel Macs in 2024-2025 and GitHub reduced macos-13 runner capacity to effectively zero free-tier availability.

Fix: switch the darwin-x64 row from `macos-13` to `macos-latest` (macos-14 = arm64). Our binary is pure JavaScript bundled via esbuild — no Intel-specific native compilation. The vsce package step still passes `--target darwin-x64` so the produced .vsix is correctly marketed for Intel Mac. Intel Mac users download the same JS payload and execute it via local Node — the shebang shim works on both architectures.

**2. Version bump 0.0.3 → 0.1.0** — first real public marketplace release. v0.0.x was internal alpha; v0.1.0 marks feature-complete sidebar monitor + cooperative-by-default + cross-platform.

## After merge

1. New tag: `git tag -a extension-v0.1.0 -m "..." && git push origin extension-v0.1.0`
2. Workflow allocates darwin-x64 on macos-14 instantly, full matrix completes in ~5 minutes
3. Publish job runs `ovsx publish` per platform — 5 .vsix files land on Open VSX
4. Release becomes installable via Cursor's Extensions search

🤖 Generated with [Claude Code](https://claude.com/claude-code)
