### PR TITLE
ci+extension: release follow-ups (contents:write + LICENSE)

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:

--- a/extension/LICENSE
+++ b/extension/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AXME AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Two small follow-ups discovered during the v0.1.0 release run on 2026-05-15. Both are CI/packaging only — no extension code or runtime behaviour changes.

**1. Workflow permissions — `contents: read` → `contents: write`**

The publish workflow has two final steps:
- ✅ `Publish per-target to Open VSX` — runs `ovsx publish` per platform, lands the extension on the marketplace.
- ❌ `Attach .vsix files to GitHub Release` — was meant to also create `github.com/.../releases/extension-v0.1.0` with the 5 `.vsix` files attached for sideload installs.

The second step failed during the v0.1.0 run with `HTTP 403: Resource not accessible by integration`, because the workflow-level `permissions:` block was set to `contents: read`. `gh release create` and `gh release upload` need `contents: write`. Marketplace publish itself was unaffected.

Fix: bump the block to `contents: write`. Read remains the default for everything else; this only changes what the publish job's `GITHUB_TOKEN` is allowed to do, which is bounded to this workflow's runtime.

**2. `extension/LICENSE` — MIT copy from repo root**

`vsce package` emits `WARNING: LICENSE, LICENSE.md, or LICENSE.txt not found` because vsce looks inside the package root (`extension/`), not at the repo root. The `.vsix` files we already published to Open VSX don't carry a license file, which is suboptimal for downstream redistribution.

Fix: drop a copy of the repo MIT license into `extension/LICENSE`. Same text — both surfaces stay in sync. Next packaged `.vsix` (any v0.1.1+ release) will include it.

## Effect

These take effect on the next tag push (`extension-v0.1.1` or whatever comes next). v0.1.0 itself is already live on Open VSX and is unaffected by this PR.

## Test plan

- [ ] Merge to main
- [ ] On the next `extension-v*` tag push, verify:
  - [ ] `vsce package` step in CI logs no longer shows the LICENSE warning
  - [ ] `gh release create` step succeeds (no 403)
  - [ ] Release page `github.com/AxmeAI/axme-code/releases/tag/<tag>` exists with 5 `.vsix` files attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)
