### PR TITLE
fix(scanners): keep tool calls inside the project being initialised

### DIFF
--- a/src/agents/scanners/_scope.ts
+++ b/src/agents/scanners/_scope.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared scope-restriction preamble for all four LLM scanners
+ * (oracle, decision, safety, deploy).
+ *
+ * Why this exists: the Claude Agent SDK runs scanners with
+ * `permissionMode: "bypassPermissions"` and `allowDangerouslySkipPermissions:
+ * true` (see src/utils/agent-options.ts:278), which means Read/Glob/Grep/Bash
+ * have NO path sandbox. The `cwd` option only sets a default working
+ * directory; the LLM is still free to use absolute paths or `..` to read
+ * anything on disk. On top of that, the `claude_code` system-prompt preset
+ * cascades CLAUDE.md from the cwd upward to filesystem root by default —
+ * so in a monorepo / multi-repo workspace layout (e.g.
+ * `axme-workspace/CLAUDE.md` + `axme-workspace/<repo>/`), running setup
+ * inside a child repo silently pulls the parent workspace context into
+ * every scanner's view.
+ *
+ * Reported by @geobelsky 2026-05-16 after observing scanner output reference
+ * sibling repos and the workspace-level CLAUDE.md when setup was supposed
+ * to be repo-local.
+ *
+ * The fix is an explicit prompt-level constraint that the LLM is
+ * instructed to honor. We can't enforce this at the tool layer (SDK has no
+ * `restrictToCwd` flag), so we rely on the model following an unambiguous
+ * boundary statement at the top of every scanner prompt.
+ */
+
+/**
+ * Build a scope-restriction preamble for a scanner prompt.
+ *
+ * @param projectPath Absolute path of the project the scanner is initialising.
+ *   Used both in the boundary statement and (optionally) to whitelist the
+ *   Claude auto-memory path for that exact project.
+ * @param opts.allowAutoMemoryRead When true, the preamble whitelists the
+ *   `~/.claude/projects/<encoded-path>/memory/` location so the oracle
+ *   scanner can read accumulated cross-session memories. Other scanners
+ *   (decision/safety/deploy) don't need cross-project memory and leave
+ *   this off.
+ */
+export function buildScopeConstraint(
+  projectPath: string,
+  opts: { allowAutoMemoryRead?: boolean } = {},
+): string {
+  const allowMemory = opts.allowAutoMemoryRead === true;
+  // Compute the encoded project path the way the oracle prompt asks the LLM
+  // to compute it — replace every non-alphanumeric char with "-". We
+  // pre-compute it here so the whitelist is concrete (no LLM math required).
+  const encoded = projectPath.replace(/[^a-zA-Z0-9]/g, "-");
+  const memoryClause = allowMemory
+    ? `   - EXCEPTION: you MAY read \`~/.claude/projects/${encoded}/memory/\` ` +
+      `and its contents (this is the auto-memory store for THIS project; reading it is required).\n`
+    : "";
+
+  return `## Scope boundary (read first — do not violate)
+
+You are scanning a SINGLE project rooted at:
+
+  ${projectPath}
+
+You MUST keep every Read / Glob / Grep / Bash tool call strictly inside that directory tree.
+
+- All file paths in your tool calls must be either relative paths that resolve inside ${projectPath} or absolute paths that start with that prefix.
+- Do NOT use \`..\` to escape upward.
+- Do NOT read or list any file in the parent of ${projectPath}, or in sibling directories, or in any unrelated location on the filesystem.
+- Do NOT cd / chdir / pushd to anywhere outside ${projectPath}.
+- If the \`claude_code\` system prompt mentions parent CLAUDE.md, repo siblings, or workspace-level files, IGNORE them. The user has explicitly asked you to confine analysis to ${projectPath}.
+- If you encounter a symlink that points outside ${projectPath}, do not follow it.
+
+${memoryClause}---
+
+`;
+}

--- a/src/agents/scanners/decision.ts
+++ b/src/agents/scanners/decision.ts
@@ -12,6 +12,7 @@ import { extractCostFromResult, zeroCost, type CostInfo } from "../../utils/cost
 import { buildAgentQueryOptions } from "../../utils/agent-options.js";
 import { createAgentSdk } from "../../utils/agent-sdk.js";
 import { toSlug } from "../../storage/decisions.js";
+import { buildScopeConstraint } from "./_scope.js";
 
 export interface DecisionScanResult {
   decisions: Decision[];
@@ -113,7 +114,8 @@ export async function runDecisionScan(opts: {
     "scanner",
   );
 
-  let prompt = DECISION_SCAN_PROMPT;
+  // Scope boundary — see src/agents/scanners/_scope.ts header for why.
+  let prompt = buildScopeConstraint(opts.projectPath) + DECISION_SCAN_PROMPT;
   if (opts.existingDecisions && opts.existingDecisions.length > 0) {
     const list = opts.existingDecisions.map(d =>
       `- ${d.id}: ${d.title} [${d.enforce ?? "info"}] — ${d.decision}`

--- a/src/agents/scanners/deploy.ts
+++ b/src/agents/scanners/deploy.ts
@@ -11,6 +11,7 @@ import type { ChecklistItem } from "../../types.js";
 import { extractCostFromResult, zeroCost, type CostInfo } from "../../utils/cost-extractor.js";
 import { buildAgentQueryOptions } from "../../utils/agent-options.js";
 import { createAgentSdk } from "../../utils/agent-sdk.js";
+import { buildScopeConstraint } from "./_scope.js";
 
 export interface DeployScanResult {
   stagingItems: ChecklistItem[];
@@ -95,7 +96,9 @@ export async function runDeployScan(opts: {
     "scanner",
   );
 
-  const q = sdk.query({ prompt: DEPLOY_SCAN_PROMPT, options: queryOpts });
+  // Scope boundary — see src/agents/scanners/_scope.ts header for why.
+  const prompt = buildScopeConstraint(opts.projectPath) + DEPLOY_SCAN_PROMPT;
+  const q = sdk.query({ prompt, options: queryOpts });
 
   let result = "";
   let cost: CostInfo | undefined;

--- a/src/agents/scanners/oracle.ts
+++ b/src/agents/scanners/oracle.ts
@@ -11,6 +11,7 @@ import type { OracleFiles } from "../../types.js";
 import { extractCostFromResult, zeroCost, type CostInfo } from "../../utils/cost-extractor.js";
 import { buildAgentQueryOptions } from "../../utils/agent-options.js";
 import { createAgentSdk } from "../../utils/agent-sdk.js";
+import { buildScopeConstraint } from "./_scope.js";
 
 export interface OracleScanResult {
   files: OracleFiles;
@@ -130,7 +131,11 @@ export async function runOracleScan(opts: {
     "scanner",
   );
 
-  let prompt = ORACLE_SCAN_PROMPT;
+  // Scope boundary: keep all Read/Glob/Grep/Bash tool calls inside
+  // opts.projectPath. Oracle is the one scanner that legitimately reads
+  // outside cwd (the Claude auto-memory dir at ~/.claude/projects/<encoded>/),
+  // so we whitelist that exception explicitly. See _scope.ts header.
+  let prompt = buildScopeConstraint(opts.projectPath, { allowAutoMemoryRead: true }) + ORACLE_SCAN_PROMPT;
 
   if (opts.workspaceMode) {
     prompt += `\n\n## WORKSPACE MODE - IMPORTANT

--- a/src/agents/scanners/safety.ts
+++ b/src/agents/scanners/safety.ts
@@ -11,6 +11,7 @@ import type { SafetyRules } from "../../types.js";
 import { extractCostFromResult, zeroCost, type CostInfo } from "../../utils/cost-extractor.js";
 import { buildAgentQueryOptions } from "../../utils/agent-options.js";
 import { createAgentSdk } from "../../utils/agent-sdk.js";
+import { buildScopeConstraint } from "./_scope.js";
 
 export interface SafetyScanResult {
   rules: Partial<SafetyRules>;
@@ -103,7 +104,9 @@ export async function runSafetyScan(opts: {
     "scanner",
   );
 
-  const q = sdk.query({ prompt: SAFETY_SCAN_PROMPT, options: queryOpts });
+  // Scope boundary — see src/agents/scanners/_scope.ts header for why.
+  const prompt = buildScopeConstraint(opts.projectPath) + SAFETY_SCAN_PROMPT;
+  const q = sdk.query({ prompt, options: queryOpts });
 
   let result = "";
   let cost: CostInfo | undefined;


### PR DESCRIPTION
## Summary

**Bug**: `axme-code setup` in a child repo of a multi-repo workspace (e.g. `axme-workspace/<repo>/`) silently pulls in the parent workspace's `CLAUDE.md` and may explore sibling repos. Reported 2026-05-16: oracle/decision output referenced files outside the target project.

**Root cause** — two collaborating defaults:

1. `src/utils/agent-options.ts:278` — all four scanners (oracle, decision, safety, deploy) run with `permissionMode: "bypassPermissions"` + `allowDangerouslySkipPermissions: true`. This is intentional (we don't want the scanner to halt on permission prompts), but it also removes the path sandbox — `Read` / `Glob` / `Grep` / `Bash` are free to resolve `..` or absolute paths to anywhere on disk.

2. The `claude_code` system-prompt preset cascades `CLAUDE.md` from `cwd` upward to filesystem root by default. In a flat single-repo layout that's a no-op (no parent CLAUDE.md exists). In a workspace layout it silently injects the workspace context.

The Claude Agent SDK has no `restrictToCwd` / `disallowDirectories` option (verified by reading [node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts](node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts)) — `additionalDirectories` only ADDs paths, doesn't restrict. So enforcement has to be at the prompt level.

## Fix

New shared helper [src/agents/scanners/_scope.ts](src/agents/scanners/_scope.ts) builds an explicit boundary preamble:

- states the absolute project path
- forbids `..`, parent reads, sibling dirs, `chdir` to outside, symlink follow-out
- explicitly tells the LLM to ignore parent `CLAUDE.md` if the system prompt surfaces it
- oracle keeps a single whitelisted exception for the per-project auto-memory dir (`~/.claude/projects/<encoded-path>/memory/`), since that's a legitimate cross-session read; other scanners don't need it

The four scanners now prepend this constraint to their existing prompts.

## Files changed

| File | Change |
| --- | --- |
| `src/agents/scanners/_scope.ts` | **new** — boundary preamble helper |
| `src/agents/scanners/oracle.ts` | prepend constraint (with auto-memory whitelist) |
| `src/agents/scanners/decision.ts` | prepend constraint |
| `src/agents/scanners/safety.ts` | prepend constraint |
| `src/agents/scanners/deploy.ts` | prepend constraint |

+88 / −4. Type-check + build clean.

## Cost / tradeoffs

- ~250 tokens of fixed preamble per scanner run — negligible vs. typical 5k-20k scan output
- This is prompt-level guidance, not a hard sandbox. A misbehaving model could in theory ignore the boundary. In practice Claude follows explicit boundary statements very reliably; we can layer additional defense via post-hoc tool-call filtering if a regression appears.
- No behaviour change for single-repo layouts (no parent CLAUDE.md exists → cascade is a no-op anyway). Workspace-layout users now get the expected scoped scan.

## Test plan

- [ ] Merge to main
- [ ] Re-run setup inside `axme-workspace/axme-code/` (the reporter's case) — oracle output should reference only files inside `axme-code/`, not `axme-workspace/CLAUDE.md` or sibling repos
- [ ] Run setup inside a single-repo project (e.g. a fresh `git init` somewhere with one folder) — output unchanged
- [ ] Existing unit tests (`npm test`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
