### PR TITLE
release(extension): v0.1.1 — Linux + macOS only, Windows pulled until verified

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -45,10 +45,25 @@ jobs:
             runner: macos-latest
             binary_name: axme-code-darwin-arm64
             extension_bin: axme-code
-          - target: win32-x64
-            runner: windows-latest
-            binary_name: axme-code-windows-x64.exe
-            extension_bin: axme-code.exe
+          # win32-x64 temporarily disabled for v0.1.1 release. v0.1.0
+          # shipped with a broken Windows .vsix (shebang-shim binary that
+          # Windows can't execute as PE — see PR #136 for the
+          # ELECTRON_RUN_AS_NODE fix). Even with the fix the user
+          # reported the extension still didn't work end-to-end, so
+          # we're pulling Windows from the build/publish path until we
+          # can verify it on a real Windows machine. Re-enable in v0.1.2
+          # once a real-machine smoke test passes.
+          #
+          # NOTE: Open VSX is immutable, so v0.1.0@win32-x64 stays
+          # visible on the marketplace until Eclipse Foundation
+          # processes a manual unpublish request. New v0.1.1+ tags
+          # won't publish a Windows .vsix; Windows users searching the
+          # marketplace will see v0.1.0 as the latest Windows target.
+          #
+          # - target: win32-x64
+          #   runner: windows-latest
+          #   binary_name: axme-code-windows-x64.exe
+          #   extension_bin: axme-code.exe
     steps:
       - uses: actions/checkout@v4
 
@@ -192,7 +207,13 @@ jobs:
           OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
         run: |
           set -euo pipefail
-          for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64; do
+          # win32-x64 temporarily dropped from the publish loop (see build
+          # matrix comment for context). Re-add when Windows is verified
+          # to work on a real machine. The "Warning: $file missing"
+          # branch tolerates a missing target gracefully — if win32-x64
+          # gets re-added in the build matrix later, the publish step
+          # picks it up automatically without a separate edit.
+          for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
             file="vsix/axme-code-${target}.vsix"
             if [ ! -f "$file" ]; then
               echo "Warning: $file missing; skipping $target."
@@ -207,11 +228,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Create release if missing, then attach all 5 .vsix files for
-          # sideload distribution alongside Open VSX.
+          # Create release if missing, then attach the platform-specific
+          # .vsix files for sideload distribution alongside Open VSX.
+          # NOTE: count depends on which targets are active in the build
+          # matrix above. v0.1.1 dropped win32-x64 → 4 files. The for-loop
+          # below globs whatever artifacts CI uploaded, so adding targets
+          # doesn't need a separate edit here.
           tag="${GITHUB_REF#refs/tags/}"
           gh release view "$tag" >/dev/null 2>&1 || \
-            gh release create "$tag" --title "$tag" --notes "Extension $tag — six platform-specific .vsix files attached. See README for install instructions."
+            gh release create "$tag" --title "$tag" --notes "Extension $tag — platform-specific .vsix files attached. See README for install instructions."
           for f in vsix/axme-code-*.vsix; do
             gh release upload "$tag" "$f" --clobber
           done

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="media/icon.png" width="160" height="160" alt="AXME Code logo" />
+  <img src="https://raw.githubusercontent.com/AxmeAI/axme-code/main/extension/media/icon.png" width="160" height="160" alt="AXME Code logo" />
 </p>
 
 # AXME Code

--- a/extension/README.md
+++ b/extension/README.md
@@ -43,22 +43,23 @@ The sidebar exposes additional one-click flows: **Ask agent to setup** (cooperat
 
 The `axme-code` CLI alone writes `.cursor/mcp.json` and `.cursor/hooks.json` per project. Cursor 0.42+ requires a manual **Enable** click in Settings → MCP for any new project-level server (security feature). This extension registers MCP via Cursor's extension API directly, bypassing the per-project Enable gate — install the extension once, every project just works.
 
-## Platform support (v0.0.3)
+## Platform support (v0.1.1)
 
 | Platform | Bundled CLI | Setup + MCP + hooks | Sidebar UI | Notes |
 | --- | --- | --- | --- | --- |
 | **macOS arm64** (Apple Silicon) | ✅ verified | ✅ verified | ✅ verified | Primary dev/test platform; full UI verification done |
 | **Linux x64** | ✅ verified | ✅ verified | ⚠️ binary verified, full UI not yet sampled | CI matrix runs the 608-test core suite + binary self-test on every push |
 | **Linux arm64** | ✅ CI builds | ✅ via CI runner | ❌ not verified | First-class target via Open VSX matrix publish |
-| **Windows x64** | ✅ verified headlessly (Azure VM) | ✅ verified — setup wrote oracle/decisions/memories/safety, hooks.json correct | ❌ real Cursor UI not yet verified | See "Windows notes" below |
 | **macOS x64** (Intel) | ⚠️ CI builds | ⚠️ untested | ❌ untested | Apple discontinuing Intel; ship best-effort |
-| **Windows arm64** | ⚠️ no CI runner yet | ❌ untested | ❌ untested | GitHub Actions free tier lacks this runner as of 2026 |
+| **Windows** | ⏸ temporarily not published | ⏸ | ⏸ | See "Windows status" below |
 
-### Windows notes
+### Windows status
 
-The bundled `axme-code` binary inside the `.vsix` is a shebang shim — text starting with `#!/usr/bin/env node` followed by a CJS payload. POSIX (Linux/macOS) honours the shebang and executes it directly. **Windows ignores shebangs**, so the binary is always invoked via `node` on Windows — both internally (extension's spawnBinary helper) and in the generated `~/.cursor/hooks.json` commands.
+v0.1.0 shipped a `win32-x64` build that did not work end-to-end on a real Cursor install (MCP server failed to boot, sidebar empty). v0.1.1 contains an `ELECTRON_RUN_AS_NODE` fix (PR #136) that should resolve it, but at release time we hadn't verified the fix on a real Windows machine, so we **dropped Windows from the publish matrix for v0.1.1 to avoid offering a known-broken build**.
 
-**Requirement on Windows**: `node` must be on the user's PATH. The vast majority of Windows Cursor users have Node installed for dev work; if you don't, install from <https://nodejs.org> first.
+If you're on Windows: skip the extension for now and use the standalone Claude Code CLI flow (`curl ... | sh` install then `axme-code setup` in your project). Windows extension support returns in v0.1.2 once a real-Cursor smoke test passes.
+
+The previously-published `v0.1.0@win32-x64` is still visible on Open VSX (the registry is immutable — extensions can't be unpublished without an Eclipse Foundation manual request). Windows users searching the marketplace will see v0.1.0 as the latest Windows version. Please don't install it; it doesn't work.
 
 ### macOS notes
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "axme-code",
   "displayName": "AXME Code",
   "description": "Persistent memory, decisions, and safety guardrails for Cursor, GitHub Copilot, Cline, Continue, Roo Code, Windsurf, and VS Code chat agents",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "AxmeAI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

**Release v0.1.1 prep**: bump version, drop Windows from publish matrix, refresh platform support docs.

## Why drop Windows

v0.1.0 shipped a `win32-x64` .vsix that did not work end-to-end on a real Cursor install — reported by @geobelsky:
- MCP server failed to boot ("MCP server does not exist")
- Sidebar webview empty
- Setup couldn't complete (no MCP → no tool calls)

PR #136 landed the `ELECTRON_RUN_AS_NODE` fix that should resolve all three, but at v0.1.1 release time the fix wasn't verified on a real Windows machine. Pulling Windows from the publish matrix avoids offering a second known-broken build to marketplace users. Re-enable in v0.1.2 once a real-Cursor smoke test passes.

## What v0.1.1 ships

Four platform-specific .vsix files: `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`.

Accumulated core fixes since v0.1.0 (already in main, no rebuild surprise):
- **#135** — workflow `contents: write` + bundled `LICENSE`
- **#136** — Windows binary spawn via Electron's bundled Node (code lives in main; just doesn't ship in v0.1.1 because no Windows .vsix is built/published)
- **#137** — scanner scope constraint (no parent-dir / sibling-repo traversal)

## What v0.1.1 does NOT ship

- `win32-x64` .vsix
- The previously-published `v0.1.0@win32-x64` **remains visible on Open VSX**. The registry is immutable — extensions can't be unpublished without an Eclipse Foundation manual request. Windows users searching the marketplace will see v0.1.0 as the latest Windows version. The updated extension README warns them not to install it.

## Changes

| File | Change |
| --- | --- |
| `.github/workflows/publish-extension.yml` | comment out `win32-x64` row in build matrix + drop `win32-x64` from publish loop; soften Release-notes string to not hardcode "5 files" |
| `extension/package.json` | `0.1.0` → `0.1.1` |
| `extension/README.md` | refresh "Platform support" table + new "Windows status" section |

+41 / −15.

## After merge

```bash
git checkout main && git pull
git tag -a extension-v0.1.1 -m "v0.1.1 — Linux + macOS (Windows pulled, see PR #138)"
git push origin extension-v0.1.1
```

CI matrix → 4 .vsix files → Open VSX publish per target → GitHub Release auto-created.

## Follow-up (separate work, not blocking)

- File Eclipse Foundation issue requesting `v0.1.0@win32-x64` unpublish so the broken build stops appearing in Windows search results. Eclipse Foundation handles this manually; takes days.
- Verify v0.1.1 ELECTRON_RUN_AS_NODE fix end-to-end on a real Windows machine using a CI artifact .vsix. If green, re-enable `win32-x64` in the matrix and cut v0.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
