### PR TITLE
fix(scanners): block reads from credential / secret paths

### DIFF
--- a/src/agents/scanners/_scope.ts
+++ b/src/agents/scanners/_scope.ts
@@ -65,7 +65,31 @@ You MUST keep every Read / Glob / Grep / Bash tool call strictly inside that dir
 - If the \`claude_code\` system prompt mentions parent CLAUDE.md, repo siblings, or workspace-level files, IGNORE them. The user has explicitly asked you to confine analysis to ${projectPath}.
 - If you encounter a symlink that points outside ${projectPath}, do not follow it.
 
-${memoryClause}---
+${memoryClause}## Sensitive paths — never read, never include
+
+The following locations frequently contain plaintext secrets (API keys, passwords, tokens, private keys, cloud credentials). They may exist inside ${projectPath} regardless of the project's \`.gitignore\`. You MUST NOT Read, Glob, Grep, or cat these — and if you incidentally see their contents in any other tool's output, you MUST NOT echo, summarise, paraphrase, or include those contents in your final report.
+
+Directory names (anywhere in the tree):
+- \`credentials/\`, \`secrets/\`, \`keys/\`, \`certs/\`, \`private/\`
+- \`.aws/\`, \`.ssh/\`, \`.gnupg/\`, \`.docker/\`
+- \`.kube/\` (kubeconfig leaks cluster admin creds)
+
+File patterns (anywhere in the tree):
+- \`.env\`, \`.env.*\` (including \`.env.local\`, \`.env.production\`, etc.) — note \`.env.example\` / \`.env.template\` ARE safe to read, only the populated variants are sensitive
+- \`*.pem\`, \`*.key\`, \`*.p12\`, \`*.pfx\`, \`*.jks\`, \`*.keystore\` — TLS / PKCS / Java keystore material
+- \`id_rsa\`, \`id_dsa\`, \`id_ecdsa\`, \`id_ed25519\` (with or without \`.pub\` — though \`.pub\` files are technically safe, treat the whole family as off-limits)
+- \`service-account*.json\`, \`gcp-key*.json\`, \`firebase-adminsdk*.json\` — GCP / Firebase service account keys
+- \`.npmrc\`, \`.pypirc\`, \`.netrc\`, \`.pgpass\`, \`.git-credentials\` — package-registry / DB / git credential files
+- \`secrets.yml\`, \`secrets.yaml\`, \`secret-*.json\`, \`config/master.key\` (Rails) — common explicit secret files
+
+What you SHOULD still do:
+- Note the EXISTENCE of these files (e.g. "project uses .env for configuration" or "AWS credentials present at .aws/credentials") in STACK / safety output — existence is useful context, contents are not.
+- Read \`.gitignore\` itself to see what the project considers sensitive; if you see additional secret-like patterns there beyond this list, treat those paths as sensitive too.
+- Read \`.env.example\` / \`.env.template\` / \`.env.sample\` — these document required env vars without populated values.
+
+If asked to fill out a STACK / DEPENDENCIES / SECURITY section that references credentials, write "uses [service X] — credentials provisioned via .env / .aws / etc." and stop. Do NOT include the actual values.
+
+---
 
 `;
 }


### PR DESCRIPTION
## Summary

**Privacy review finding** (reported 2026-05-17): the LLM scanners that run at `axme-code setup` time have unfiltered Read / Glob / Grep / Bash access across the entire project tree. The Claude Agent SDK only excludes `node_modules`, `.git`, and `dist` by default — there is no built-in secret-path filter, and AXME does not currently parse `.gitignore` for additional exclusions.

If a project contains plaintext secrets in conventional locations (a populated `.env`, `credentials/`, `~/.aws/credentials`, a Firebase / GCP service-account JSON, etc.), the oracle / decision / safety / deploy scanner can incidentally read them and copy the values into the generated knowledge-base files under `.axme-code/`.

## What this fix covers

Adds a "Sensitive paths — never read, never include" block to [src/agents/scanners/_scope.ts](src/agents/scanners/_scope.ts). Every scanner already prepends this scope preamble to its prompt (PR #137), so the new instruction is delivered to all four scanners with no per-scanner changes.

**Blocked directories** (anywhere in the tree):
- `credentials/`, `secrets/`, `keys/`, `certs/`, `private/`
- `.aws/`, `.ssh/`, `.gnupg/`, `.docker/`, `.kube/`

**Blocked file patterns:**
- `.env`, `.env.*` (allowlist `.env.example` / `.template` / `.sample` — those document required vars without populated values)
- `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`, `*.keystore`
- `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519` (incl. `.pub` to keep the family rule simple)
- `service-account*.json`, `gcp-key*.json`, `firebase-adminsdk*.json`
- `.npmrc`, `.pypirc`, `.netrc`, `.pgpass`, `.git-credentials`
- `secrets.yml`, `secrets.yaml`, `secret-*.json`, `config/master.key`

**Instruction is twofold:**
1. Never read these directly.
2. If contents leak in via another tool's output, never echo / summarise / paraphrase the values.

Scanner is still permitted (and encouraged) to note the EXISTENCE of these files — that's legitimate context for the future agent — but not the contents.

**Bonus**: the prompt also tells the scanner to read `.gitignore` and infer additional sensitive patterns from there, so projects with unusual secret-file conventions are partially auto-protected.

## What this fix does NOT cover

- **Runtime auditor reading chat transcripts that contain secret values**. General LLM-safety problem; users mitigated by not pasting / `cat`-ing secrets in chat.
- **PostToolUse hook ingesting secrets**. Verified during the review — the hook only records file *paths*, never content. No fix needed.

## Mechanism caveat

This is a **prompt-level constraint**, not a hard sandbox. The Claude Agent SDK has no `disallowedPaths` API; tool restrictions are by tool name, not by argument. Mitigation: the list is at the top of every scanner prompt right after the cwd boundary, where Claude follows explicit boundary statements very reliably. We can layer post-hoc tool-call filtering later if a regression appears.

## Test plan

- [ ] Merge to main
- [ ] Create a test project with a fake `.env` containing dummy `FAKE_API_KEY=sk-not-real` and a `credentials/aws.json` with dummy AWS creds
- [ ] Run `axme-code setup` — verify the `.env` / `credentials/aws.json` contents do NOT appear in any `.axme-code/oracle/*.md`, `.axme-code/decisions/*.md`, or `.axme-code/safety/rules.yaml`
- [ ] Verify the scanner still mentions ".env present" / "uses AWS credentials" as factual existence claims in the STACK section
- [ ] Existing core test suite (`npm test`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
