### PR TITLE
release(extension): v0.1.4 — README logo uses absolute GitHub raw URL

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="media/icon.png" width="160" height="160" alt="AXME Code logo" />
+  <img src="https://raw.githubusercontent.com/AxmeAI/axme-code/main/extension/media/icon.png" width="160" height="160" alt="AXME Code logo" />
 </p>
 
 # AXME Code

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "axme-code",
   "displayName": "AXME Code",
   "description": "Persistent memory, decisions, and safety guardrails for Cursor, GitHub Copilot, Cline, Continue, Roo Code, Windsurf, and VS Code chat agents",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "AxmeAI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Open VSX renders the marketplace listing's README on its own site (https://open-vsx.org/extension/AxmeAI/axme-code) and **doesn't resolve relative paths** into the .vsix bundle. v0.1.0 through v0.1.3 ship with `<img src="media/icon.png">` — relative — so the listing renders a broken-image icon with the alt text "AXME Code logo".

Reported by @geobelsky 2026-05-19 after v0.1.3 publish.

## Why the logo works in some places but not others

- ✅ **Inside Cursor / VS Code** (extension page top-left icon, Activity Bar icon, sidebar header) — these read from `package.json` `"icon": "media/icon.png"` which is loaded by the IDE host, with the .vsix as the resolution root. The file is shipped in the .vsix and resolves correctly.
- ❌ **Open VSX listing page** — Open VSX is a marketplace UI that renders README.md text on its own web server. Relative paths in img `src` have no .vsix context to resolve against.

## Fix

Same one-line change that was originally landed in PR #138 (commit e9f833d) but lost because that PR was closed without merge:

```html
<img src="https://raw.githubusercontent.com/AxmeAI/axme-code/main/extension/media/icon.png"
     width="160" height="160" alt="AXME Code logo" />
```

GitHub raw content is publicly fetchable, no auth needed, no CORS issues on Open VSX side. Standard pattern (Mem0, Cline, others use the same).

## After merge

1. Push tag `extension-v0.1.4` (same flow as v0.1.3)
2. CI builds + publishes to Open VSX
3. Listing page now shows the AXME logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)