### PR TITLE
feat(telemetry): capture error_class on setup_complete failures

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -425,6 +425,7 @@ async function main() {
       let setupOutcome: "success" | "fallback" | "failed" = "failed";
       let setupMethod: "llm" | "deterministic" = "deterministic";
       let setupPhaseFailed: string | null = null;
+      let setupErrorClass: import("./telemetry.js").ErrorClass | null = null;
       let setupPresetsApplied = 0;
       let setupScannersRun = 0;
       let setupScannersFailed = 0;
@@ -441,6 +442,7 @@ async function main() {
             scanners_run: setupScannersRun,
             scanners_failed: setupScannersFailed,
             phase_failed: setupPhaseFailed,
+            error_class: setupErrorClass,
             presets_applied: setupPresetsApplied,
             is_workspace: isWorkspace,
             child_repos: childRepos,
@@ -463,6 +465,7 @@ async function main() {
         console.error(`  export ANTHROPIC_API_KEY=sk-ant-...  (API key)\n`);
         setupOutcome = "failed";
         setupPhaseFailed = "auth_check";
+        setupErrorClass = "oauth_missing";
         await sendSetupTelemetry();
         process.exit(1);
       }
@@ -517,7 +520,8 @@ async function main() {
         setupOutcome = "failed";
         setupPhaseFailed = "init_scan";
         const { classifyError, reportError } = await import("./telemetry.js");
-        try { reportError("setup", classifyError(err), true); } catch { /* swallow */ }
+        setupErrorClass = classifyError(err);
+        try { reportError("setup", setupErrorClass, true); } catch { /* swallow */ }
         await sendSetupTelemetry();
         throw err;
       }


### PR DESCRIPTION
## Summary

When setup fails, the dashboard's *Phase Failures* view (`/admin/analytics` → Code → Setup health) showed only the failed phase — `auth_check: 7`, `init_scan: 1` — but `error_class` was always NULL, so it was impossible to tell *why* setup failed without grepping logs.

This PR populates `error_class` on the `setup_complete` event:

| Phase | error_class set to | Why |
|---|---|---|
| `auth_check` | `"oauth_missing"` | No Claude subscription and no `ANTHROPIC_API_KEY` env var — caller never authenticated. Slug already exists in the bounded `ErrorClass` vocab. |
| `init_scan`  | `classifyError(err)` | Same classification we already feed into the separate `error` event; now also stamped onto `setup_complete` so it's visible in one row of the dashboard's Phase Failures table. |

Backend ingestion already reads `error_class` from any event payload ([misc_routes.py:2100](https://github.com/AxmeAI/axme-control-plane/blob/main/services/gateway/misc_routes.py#L2100)) — no migration, no schema change.

## Why now

Dashboard at https://cloud.axme.ai/admin/analytics currently shows:
- `auth_check: 7` — looking at raw rows, these are all real users who ran `axme-code setup` without authenticating. **Not a bug** — but with this fix the dashboard will show `auth_check / oauth_missing: 7` so an operator can read it without DB access.
- `init_scan: 1` — one user's LLM scan threw; `error_class` was NULL so I couldn't tell from the dashboard whether it was `timeout`, `api_error`, `api_rate_limit`, etc. With this fix the next such failure will be self-describing.

## Files changed

[src/cli.ts](src/cli.ts) — 5 lines:
- Add `setupErrorClass: ErrorClass | null` next to existing `setupPhaseFailed`.
- Set on `auth_check` and `init_scan` branches.
- Include `error_class` in the `sendTelemetryBlocking("setup_complete", { ... })` payload.

## Test plan

- [x] Type-check clean (`npx tsc --noEmit`)
- [x] Full unit test suite passes (608/608)
- [x] Bundle builds (`npm run build`)
- [ ] After next release: verify `error_class` populated for any new setup-failed rows on the dashboard

## After merge

Effective for users on the next CLI release. Existing rows in `telemetry_events` are unchanged — the historical 7 + 1 stay NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)