### PR TITLE
fix(ci): mark @cursor/sdk external in standalone-binary bundle step

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -57,10 +57,20 @@ jobs:
       - name: Create standalone bundle
         run: |
           mkdir -p release
-          # Bundle everything into a single file with node shebang
+          # Bundle everything into a single file with node shebang.
+          # @cursor/sdk is marked external because its TypeScript declarations
+          # re-export internal workspace paths (`@anysphere/cursor-sdk-local-runtime/*`,
+          # `./messages.js`, `./platform.js`, etc.) that esbuild cannot resolve
+          # in this second-pass bundle step. The SDK is in optionalDependencies
+          # and the AgentSdk factory falls back to the Claude wrapper via a
+          # MODULE_NOT_FOUND-tolerant dynamic import — standalone-binary users
+          # are not on Cursor (Cursor users get the .vsix), so the runtime
+          # fallback is correct. build.mjs's plugin variant already marks the
+          # same package external for the same reason (see build.mjs:74).
           npx esbuild dist/cli.mjs --bundle --platform=node --target=node20 \
             --outfile=release/axme-code-${{ matrix.target }} \
-            --banner:js='#!/usr/bin/env node'
+            --banner:js='#!/usr/bin/env node' \
+            --external:@cursor/sdk
           chmod +x release/axme-code-${{ matrix.target }}
 
       - name: Upload artifact


### PR DESCRIPTION
## Why

The `v0.6.0` tag push triggered `release-binary.yml` and the build matrix failed on all 6 platforms ([failed run](https://github.com/AxmeAI/axme-code/actions/runs/26875301334)) with:

\`\`\`
✘ [ERROR] Could not resolve \"@anysphere/cursor-sdk-local-runtime/run-store\"
   node_modules/@cursor/sdk/dist/esm/public-api.d.ts:2:189
✘ [ERROR] Could not resolve \"./messages.js\"
✘ [ERROR] Could not resolve \"./platform.js\"
... (46 errors total)
\`\`\`

## Diagnosis

`release-binary.yml` does a **second-pass** esbuild on top of `dist/cli.mjs` to produce a single self-contained file per platform. In v0.6.0 we added `@cursor/sdk` as an **optionalDependency** for first-class Cursor IDE support (PR #129). Its TypeScript declarations re-export internal workspace paths (`@anysphere/cursor-sdk-local-runtime/*`, `./messages.js`, `./platform.js`, etc.) that don't exist as resolvable modules in the published package — they're build-internal references.

`build.mjs` already knows about this — the plugin variant marks `@cursor/sdk` external for the exact same reason ([build.mjs:74](build.mjs#L74)). But the inline esbuild call in the release workflow doesn't pass that flag, so it walks the type re-exports and dies.

## Fix

One-line workflow change: add `--external:@cursor/sdk` to the second-pass esbuild bundle call.

Effects:
- **Standalone binary**: `@cursor/sdk` is no longer bundled. The AgentSdk factory's dynamic `await import(\"@cursor/sdk\")` returns MODULE_NOT_FOUND and falls back to the Claude wrapper — exactly the path standalone-binary users (curl|bash install, not Cursor) actually need.
- **Cursor extension (.vsix)**: unaffected — `@cursor/sdk` ships there via the extension's own bundling path. (Extension publish v0.1.5 succeeded on the same commit.)
- **Plugin sync** (`AxmeAI/axme-code-plugin`): unaffected — `build.mjs` already externalizes `@cursor/sdk` for the plugin variant.
- **npm publish** (`@axme/code`): unaffected — npm install resolves optionalDependencies independently; users who want Cursor SDK at runtime get it via `npm install`.

## What needs to happen after this PR merges

The `v0.6.0` tag has already been pushed and is bound to the broken commit. To re-fire the workflow against the fixed commit, the tag needs to be moved:

\`\`\`bash
# After this PR merges, from a fresh main checkout:
git checkout main && git pull origin main

# Move v0.6.0 to the fixed commit
git push origin :refs/tags/v0.6.0    # delete remote tag
git tag -d v0.6.0                     # delete local tag
git tag v0.6.0                        # re-tag at current HEAD (has the fix)
git push origin v0.6.0                # fires release-binary workflow with the fix
\`\`\`

The previous failed runs are harmless — no GitHub Release was created, no npm publish happened, no plugin-repo sync. The matrix failed before any external side effect, all downstream jobs (`release` / `publish-npm` / `sync-plugin-repo`) were skipped.

## Test plan

- [x] Workflow YAML syntactically valid (Edit succeeded, no shell errors)
- [x] `build.mjs` already uses the same `external: [\"@cursor/sdk\"]` strategy for the plugin variant — pattern proven
- [ ] After merge + retag: workflow run succeeds end-to-end (6 binaries + GitHub Release + npm publish + plugin sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)