### PR TITLE
fix(install): skip extension-v* releases when picking latest CLI

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,10 +26,20 @@ function Get-Arch {
 }
 
 function Get-LatestTag {
-    $url = "https://api.github.com/repos/$Repo/releases/latest"
+    # We publish two parallel release tracks under the same repo:
+    #   v*           — CLI binary releases (this script installs these).
+    #   extension-v* — VS Code / Cursor extension .vsix releases.
+    # /releases/latest returns whichever was published most recently overall and
+    # can flip to an extension release any time we publish an extension after a
+    # CLI release — that yields the `extension-v*` tag and a 404 when this
+    # script tries to download `axme-code-$platform` from it. Fetch the list
+    # endpoint instead and filter to the first `v[0-9]…` tag.
+    $url = "https://api.github.com/repos/$Repo/releases?per_page=30"
     try {
-        $release = Invoke-RestMethod -Uri $url -Headers @{ 'User-Agent' = 'axme-code-installer' }
-        return $release.tag_name
+        $releases = Invoke-RestMethod -Uri $url -Headers @{ 'User-Agent' = 'axme-code-installer' }
+        $cliRelease = $releases | Where-Object { $_.tag_name -match '^v[0-9]' } | Select-Object -First 1
+        if (-not $cliRelease) { throw "No CLI release (tag matching ^v[0-9]) found in the 30 most recent releases." }
+        return $cliRelease.tag_name
     } catch {
         throw "Failed to fetch latest release from $url : $($_.Exception.Message)"
     }

--- a/install.sh
+++ b/install.sh
@@ -27,11 +27,19 @@ detect_platform() {
 
 # Get latest release tag from GitHub API
 get_latest_version() {
-  local url="https://api.github.com/repos/${REPO}/releases/latest"
+  # We publish two parallel release tracks under the same repo:
+  #   - `v*`              — CLI binary releases (this script installs these).
+  #   - `extension-v*`    — VS Code / Cursor extension .vsix releases.
+  # `/releases/latest` returns the most recently published release overall and
+  # can flip to an extension release any time we publish an extension after a
+  # CLI release. That returns the `extension-v*` tag, and the binary download
+  # URL `axme-code-${platform}` 404s because the extension release only ships
+  # `.vsix` files. Fetch the recent list and filter to the first `v[0-9]…` tag.
+  local url="https://api.github.com/repos/${REPO}/releases?per_page=30"
   if command -v curl &>/dev/null; then
-    curl -fsSL "$url" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//'
+    curl -fsSL "$url" | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//' | grep -E '^v[0-9]' | head -1
   elif command -v wget &>/dev/null; then
-    wget -qO- "$url" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//'
+    wget -qO- "$url" | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//' | grep -E '^v[0-9]' | head -1
   else
     echo "Neither curl nor wget found" >&2; exit 1
   fi


### PR DESCRIPTION
## Why

A user trying to install on a fresh box just now:

\`\`\`
$ curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash
Detected platform: linux-x64
Fetching latest release...
Installing axme-code extension-v0.1.5 (linux-x64)...
curl: (22) The requested URL returned error: 404
\`\`\`

The installer picked the wrong tag: `extension-v0.1.5` instead of `v0.6.0`. Then tried to download `axme-code-linux-x64` from a release that only contains `.vsix` files → 404.

## Root cause

We publish two parallel release tracks from this repo:
| Tag pattern | What ships |
|---|---|
| `v*` | CLI binary releases (6 platform-specific files) |
| `extension-v*` | VS Code / Cursor extension `.vsix` bundles (5 platform-specific files) |

[install.sh:30](install.sh#L30) and [install.ps1:29](install.ps1#L29) both hit `/releases/latest`, which returns the most-recently-published release across ALL tags. Today's release order — `v0.6.0` at 09:25 UTC, then `extension-v0.1.5` at 09:30 UTC — made the extension release \"latest\" 8 hours ago. Every fresh `curl|bash install.sh` call has 404'd since.

The bug has existed since we added the extension release track but only triggers when we publish in the order \"CLI release first, then extension release.\" In v0.5.0 era we published extension releases before the CLI release ([extension-v0.1.4 → v0.5.0 was reversed](https://github.com/AxmeAI/axme-code/releases)) so the issue was masked.

## Fix

Switch both installers from `/releases/latest` to `/releases?per_page=30` and filter for the first `tag_name` matching `^v[0-9]`:

- **install.sh**: `curl ... | grep tag_name | sed ... | grep -E '^v[0-9]' | head -1`
- **install.ps1**: `Invoke-RestMethod ... | Where-Object { $_.tag_name -match '^v[0-9]' } | Select-Object -First 1`

Both pieces of logic carry a code comment explaining the two-track release model and the failure case so the next operator doesn't re-introduce it.

## Verified

Dry-runned against the live API:

\`\`\`bash
$ curl -fsSL \"https://api.github.com/repos/AxmeAI/axme-code/releases?per_page=30\" \\
    | grep '\"tag_name\"' \\
    | sed 's/.*\"tag_name\": *\"//;s/\".*//' \\
    | grep -E '^v[0-9]' | head -1
v0.6.0
\`\`\`

## Workaround until this merges

End users can still install by passing the version explicitly:

\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash -s v0.6.0
# install.ps1:  iwr ... | iex -ArgumentList v0.6.0
\`\`\`

(Both installers already accept the version as the first positional argument — [install.sh:56](install.sh#L56), [install.ps1:60](install.ps1#L60).)

## After merge

No tag, no release needed. install.sh and install.ps1 are served via `raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh` — the next `curl|bash` after merge will pick up the fix.

## Test plan

- [x] AST/syntax: `bash -n install.sh` clean (no parse error introduced)
- [x] Live-API dry-run resolves to `v0.6.0` correctly
- [ ] After merge: another `curl|bash install.sh` on a fresh box installs `v0.6.0` cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)