### PR TITLE
fix(core): launch-readiness fixes — setup, audit pipeline, auto-update, config safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Install the CLI system-wide (useful if you want to run `axme-code` outside Claud
 ```bash
 curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-code/main/install.sh | bash
 ```
-Installs to `~/.local/bin/axme-code`. Supports x64 and ARM64.
+Installs to `~/.local/bin/axme-code`. Requires Node.js 20+ on PATH (the binary is a single-file Node bundle; the installer checks for it). Supports x64 and ARM64.
 
 **Windows (native):**
 ```powershell

--- a/install.sh
+++ b/install.sh
@@ -55,11 +55,41 @@ download() {
   fi
 }
 
+# The released "binaries" are single-file Node bundles with a
+# `#!/usr/bin/env node` shebang — they need Node.js 20+ at runtime. Check
+# up-front so a Node-less user doesn't get a "successful" install followed
+# by `env: 'node': No such file or directory` on first run.
+# AXME_SKIP_NODE_CHECK=1 bypasses (e.g. node comes from a version manager
+# that is not loaded in this non-interactive shell).
+check_node() {
+  if [ -n "${AXME_SKIP_NODE_CHECK:-}" ]; then
+    return 0
+  fi
+  if ! command -v node >/dev/null 2>&1; then
+    echo "Error: Node.js 20+ is required to run axme-code, but 'node' was not found on PATH." >&2
+    echo "Install Node.js first (https://nodejs.org or your package manager), then re-run this script." >&2
+    echo "If Node IS installed but not on PATH in this shell, re-run with AXME_SKIP_NODE_CHECK=1." >&2
+    exit 1
+  fi
+  local node_major
+  node_major="$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
+  case "$node_major" in
+    ''|*[!0-9]*) ;; # unparseable version — don't block the install
+    *)
+      if [ "$node_major" -lt 20 ]; then
+        echo "Warning: Node.js $(node -v) detected; axme-code targets Node 20+. It may fail to run — please upgrade." >&2
+      fi
+      ;;
+  esac
+}
+
 main() {
   local platform version download_url tmp
 
   platform="$(detect_platform)"
   echo "Detected platform: ${platform}"
+
+  check_node
 
   if [ -n "${1:-}" ]; then
     version="$1"
@@ -69,7 +99,7 @@ main() {
   fi
 
   if [ -z "$version" ]; then
-    echo "Could not determine latest version. Specify version: ./install.sh v0.1.0" >&2
+    echo "Could not determine latest version. Specify version: ./install.sh v0.6.0" >&2
     exit 1
   fi
 

--- a/src/audit-spawner.ts
+++ b/src/audit-spawner.ts
@@ -26,13 +26,41 @@
  */
 
 import { spawn } from "node:child_process";
-import { openSync, closeSync } from "node:fs";
-import { join } from "node:path";
+import { openSync, closeSync, existsSync } from "node:fs";
+import { join, basename, dirname } from "node:path";
 import { ensureDir } from "./storage/engine.js";
 import { AXME_CODE_DIR } from "./types.js";
 import type { IdeKind } from "./types.js";
 
 const AUDIT_WORKER_LOGS_DIR = "audit-worker-logs";
+
+/**
+ * Resolve the CLI entry to spawn for `audit-session`.
+ *
+ * process.argv[1] is correct for CLI/binary installs (`axme-code`,
+ * `dist/cli.mjs`, `dist/axme-code.js`) — the running entry already
+ * dispatches subcommands. But when this spawner runs inside the plugin/npm
+ * MCP *server* entry (`server.mjs` / `server.js`, launched via
+ * `node server.mjs` from the plugin's .mcp.json), argv[1] has no CLI
+ * dispatch at all: spawning it just boots a second MCP server that ignores
+ * the `audit-session` argv and exits on stdin-end — silently killing the
+ * entire audit pipeline for plugin installs (sessions stay pending forever
+ * and orphan recovery re-queues them on every server start). In those
+ * layouts the real CLI always sits next to the server entry
+ * (plugin: cli.mjs, npm dist: cli.mjs beside server.js), so prefer the
+ * sibling CLI when argv[1] looks like a server entry.
+ */
+function resolveCliEntry(): string {
+  const arg1 = process.argv[1];
+  if (!arg1) throw new Error("audit-spawner: cannot determine CLI path from process.argv[1]");
+  if (/^server\.(mjs|cjs|js)$/.test(basename(arg1))) {
+    for (const candidate of ["cli.mjs", "cli.cjs", "cli.js"]) {
+      const sibling = join(dirname(arg1), candidate);
+      if (existsSync(sibling)) return sibling;
+    }
+  }
+  return arg1;
+}
 
 /**
  * Spawn a detached audit worker for the given session. Returns immediately
@@ -68,8 +96,7 @@ export function spawnDetachedAuditWorker(
   const fd = openSync(logPath, "a");
 
   try {
-    const cliPath = process.argv[1];
-    if (!cliPath) throw new Error("audit-spawner: cannot determine CLI path from process.argv[1]");
+    const cliPath = resolveCliEntry();
     const argv: string[] = [cliPath, "audit-session", "--workspace", workspacePath, "--session", sessionId];
     if (ide) argv.push("--ide", ide);
     const child = spawn(

--- a/src/auto-update.ts
+++ b/src/auto-update.ts
@@ -100,7 +100,15 @@ async function fetchLatestRelease(): Promise<{ tag: string; version: string } | 
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-    const resp = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+    // We publish two release tracks in one repo: `v*` (CLI binaries — what
+    // this updater installs) and `extension-v*` (.vsix only). The
+    // `/releases/latest` endpoint returns the most recently published
+    // release overall, which flips to `extension-v*` whenever an extension
+    // ships after a CLI release — semverGreater() then compares against NaN
+    // and auto-update silently stops; if an extension version ever compared
+    // greater, the download URL would 404. Same bug class as install.sh
+    // (fixed in edc4724): fetch the list and pick the first `v[0-9]…` tag.
+    const resp = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=30`, {
       headers: {
         Accept: "application/vnd.github+json",
         "User-Agent": `axme-code/${AXME_CODE_VERSION}`,
@@ -109,8 +117,9 @@ async function fetchLatestRelease(): Promise<{ tag: string; version: string } | 
     });
     clearTimeout(timeout);
     if (!resp.ok) return null;
-    const data = (await resp.json()) as { tag_name: string };
-    const tag = data.tag_name;
+    const data = (await resp.json()) as Array<{ tag_name: string }>;
+    const tag = data.map(r => r.tag_name).find(t => /^v[0-9]/.test(t));
+    if (!tag) return null;
     return { tag, version: tag.replace(/^v/, "") };
   } catch {
     return null;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -255,10 +255,23 @@ function configureHooks(projectPath: string): void {
   const claudeDir = join(projectPath, ".claude");
   const settingsPath = join(claudeDir, "settings.json");
 
-  // Read existing settings
+  // Read existing settings. If the file exists but is NOT valid JSON
+  // (hand-edited with comments / trailing commas), refuse to touch it:
+  // the old `catch { settings = {} }` fallback silently replaced the whole
+  // file — destroying the user's permissions, env, and their own hooks.
   let settings: Record<string, any> = {};
   if (existsSync(settingsPath)) {
-    try { settings = JSON.parse(readFileSync(settingsPath, "utf-8")); } catch { settings = {}; }
+    const raw = readFileSync(settingsPath, "utf-8");
+    if (raw.trim()) {
+      try {
+        settings = JSON.parse(raw);
+      } catch (err) {
+        console.error(`  .claude/settings.json: SKIPPED — existing file is not valid JSON (${(err as Error).message}).`);
+        console.error(`  Refusing to overwrite it (that would destroy your permissions/env/hooks).`);
+        console.error(`  Fix or remove ${settingsPath}, then re-run setup to install AXME hooks.`);
+        return;
+      }
+    }
   }
 
   // Remove old hooks (without --workspace) and re-create with correct path
@@ -307,7 +320,7 @@ function configureHooks(projectPath: string): void {
   // Write settings
   mkdirSync(claudeDir, { recursive: true });
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
-  console.log("  .claude/settings.json: hooks configured (PostToolUse + SessionEnd)");
+  console.log("  .claude/settings.json: hooks configured (PreToolUse + PostToolUse + SessionEnd)");
 }
 
 /**
@@ -406,15 +419,35 @@ async function main() {
         process.exit(1);
       }
       // Strip --force, --plugin, --ide and its value from positional args.
+      // Reject anything else that looks like a flag: `axme-code setup --help`
+      // (or any typo'd flag) used to fall through to the positional-path slot
+      // and kick off a full paid LLM scan into a literal `--help/` directory.
       const setupArgs: string[] = [];
-      for (let i = 0; i < args.length; i++) {
+      for (let i = 1; i < args.length; i++) {
         const a = args[i];
         if (a === "--force" || a === "--plugin") continue;
         if (a === "--ide") { i++; continue; } // also skip the value
         if (a.startsWith("--ide=")) continue;
+        if (a === "--help" || a === "-h") { usage(); process.exit(0); }
+        if (a.startsWith("-")) {
+          console.error(`Error: unknown flag for setup: ${a}`);
+          console.error("Usage: axme-code setup [path] [--force] [--plugin] [--ide=<claude-code|cursor>]");
+          process.exit(2);
+        }
         setupArgs.push(a);
       }
-      const projectPath = resolve(setupArgs[1] || ".");
+      if (setupArgs.length > 1) {
+        console.error(`Error: setup takes at most one path argument, got: ${setupArgs.join(" ")}`);
+        process.exit(2);
+      }
+      const projectPath = resolve(setupArgs[0] || ".");
+      // A typo'd path used to be silently created and scanned ($0.50+ of LLM
+      // calls against an empty dir). Setup scans an *existing* project.
+      if (setupArgs[0] && !existsSync(projectPath)) {
+        console.error(`Error: path does not exist: ${projectPath}`);
+        console.error("setup scans an existing project — check the path for typos.");
+        process.exit(2);
+      }
       const hasGitDir = existsSync(join(projectPath, ".git"));
       const ws = detectWorkspace(projectPath);
       const isWorkspace = hasGitDir ? false : ws.type !== "single";
@@ -499,6 +532,18 @@ async function main() {
           setupScannersFailed = workspaceResult.scannersFailed + projectResults.reduce((s, r) => s + r.scannersFailed, 0);
         } else {
           const result = await initProjectWithLLM(projectPath, { onProgress: console.log, force: forceSetup });
+          if (result.lockSkipped) {
+            // A fresh setup.lock is held by another process. This used to be
+            // reported as "Already initialized ... Done!" (exit 0) — wrong on
+            // every count after an interrupted setup.
+            console.error(`  Setup is already running in another process (fresh setup.lock found).`);
+            console.error(`  Wait for it to finish, or — if nothing is actually running — re-run with --force`);
+            console.error(`  (the lock also self-expires 15 minutes after the crashed setup wrote it).`);
+            setupOutcome = "failed";
+            setupPhaseFailed = "setup_lock";
+            await sendSetupTelemetry();
+            process.exit(1);
+          }
           if (!result.created && result.durationMs === 0) {
             console.log(`  Already initialized (skipped LLM scan). Use --force to re-scan.`);
             console.log(`  Decisions: ${result.decisions.count}, Memories: ${result.memories.count}`);
@@ -542,17 +587,29 @@ async function main() {
             mcpPaths.push(join(projectPath, p.path));
           }
         }
+        let mcpWritten = 0;
         for (const dir of mcpPaths) {
           const mcpPath = join(dir, ".mcp.json");
           let mcpConfig: Record<string, any> = {};
           if (existsSync(mcpPath)) {
-            try { mcpConfig = JSON.parse(readFileSync(mcpPath, "utf-8")); } catch { mcpConfig = {}; }
+            const raw = readFileSync(mcpPath, "utf-8");
+            if (raw.trim()) {
+              try {
+                mcpConfig = JSON.parse(raw);
+              } catch (err) {
+                // Same refuse-don't-clobber rule as .claude/settings.json:
+                // the old fallback dropped every other MCP server the user had.
+                console.error(`  ${mcpPath}: SKIPPED — not valid JSON (${(err as Error).message}). Fix or remove the file, then re-run setup.`);
+                continue;
+              }
+            }
           }
           if (!mcpConfig.mcpServers) mcpConfig.mcpServers = {};
           mcpConfig.mcpServers.axme = mcpEntry;
           writeFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2) + "\n", "utf-8");
+          mcpWritten++;
         }
-        console.log(`  .mcp.json: updated (${mcpPaths.length} locations)`);
+        console.log(`  .mcp.json: updated (${mcpWritten}/${mcpPaths.length} locations)`);
       } else {
         console.log(`  .mcp.json: skipped (plugin provides MCP server)`);
       }
@@ -719,11 +776,21 @@ async function main() {
 
       const checkPath = resolve(args[1] || ".");
       const claudeMdPath = join(checkPath, "CLAUDE.md");
+      // Keep this aligned with the not-initialized flow in context.ts and the
+      // PROJECT SETUP REQUIRED block in server.ts. The previous text said
+      // "run `axme-code setup --plugin` via Bash tool immediately" — but for
+      // plugin installs the binary is NOT on PATH (and CLAUDE_PLUGIN_ROOT is
+      // not exported to the Bash tool), so the agent burned a failed command
+      // and the three surfaces contradicted each other.
       const axmeSection = `## AXME Code
 
 ### Session Start (MANDATORY)
 Call axme_context at the start of every session.
-If it returns "not initialized", run \`axme-code setup --plugin\` via Bash tool immediately.
+If it returns "not initialized": offer the user AXME setup, and on consent
+EXECUTE the inline setup flow from axme_context / the server instructions
+(a sequence of axme_save_decision / axme_save_memory / axme_update_safety /
+axme_save_oracle tool calls). Do NOT try to run \`axme-code\` via the Bash
+tool — on plugin installs it is not on PATH.
 Do NOT skip — without context you will miss critical project rules.
 `;
       // Ensure CLAUDE.md has AXME section
@@ -740,7 +807,7 @@ Do NOT skip — without context you will miss critical project rules.
       if (configExists(checkPath)) {
         console.log(`[AXME Code] Knowledge base ready. Call axme_context now.`);
       } else {
-        console.log(`[AXME Code] Project not initialized. Run: axme-code setup --plugin`);
+        console.log(`[AXME Code] Project not initialized. Call axme_context and follow its inline setup flow (offer the user setup first).`);
       }
       break;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ import {
 } from "./storage/sessions.js";
 import { logEvent } from "./storage/worklog.js";
 import { spawnDetachedAuditWorker } from "./audit-spawner.js";
+import { AXME_CODE_VERSION } from "./types.js";
 
 // --- Server state (detected at startup from --workspace flag or cwd) ---
 //
@@ -250,7 +251,8 @@ function buildInstructions(): string {
         "in their language: \"AXME is not set up for this project. Want " +
         "me to do it now? I'll scan the repo and save architecture " +
         "decisions, patterns and safety rules into .axme-code/ — runs " +
-        "inline on your Cursor subscription, no extra cost.\" If the user " +
+        "inline on the subscription you already use for this chat, no " +
+        "extra API key or cost.\" If the user " +
         "agrees (any affirmative in any language), EXECUTE setup. " +
         "Important — setup is a sequence of MCP TOOL CALLS, not a plan " +
         "to describe. Bullet-listing what you would save in prose is a " +
@@ -316,7 +318,10 @@ function buildInstructions(): string {
 }
 
 const server = new McpServer(
-  { name: "axme", version: "0.1.0" },
+  // Report the real release version: serverInfo previously hardcoded
+  // "0.1.0", which made "which version is my IDE actually running?"
+  // undebuggable from the client side.
+  { name: "axme", version: AXME_CODE_VERSION },
   { instructions: buildInstructions() },
 );
 

--- a/src/setup/cursor-writers.ts
+++ b/src/setup/cursor-writers.ts
@@ -49,12 +49,21 @@ interface CursorMcpFile {
   [key: string]: unknown;
 }
 
-function readJsonOr<T extends object>(path: string, fallback: T): T {
+/**
+ * Read a JSON file, returning `fallback` when it doesn't exist (or is empty)
+ * and `null` when it exists but cannot be parsed. Callers MUST treat `null`
+ * as "refuse to write": the previous behavior (fall back to `{}` on parse
+ * error) silently replaced the user's hand-edited .cursor/mcp.json or
+ * hooks.json — destroying their other MCP servers and their own hooks.
+ */
+function readJsonOr<T extends object>(path: string, fallback: T): T | null {
   if (!existsSync(path)) return fallback;
   try {
-    return JSON.parse(readFileSync(path, "utf-8")) as T;
+    const raw = readFileSync(path, "utf-8");
+    if (!raw.trim()) return fallback;
+    return JSON.parse(raw) as T;
   } catch {
-    return fallback;
+    return null;
   }
 }
 
@@ -70,8 +79,19 @@ function writeJsonAtomic(path: string, value: unknown): void {
  * if the user later removes `.mcp.json`.
  */
 export function writeCursorMcpJson(projectPath: string): void {
+  // When setup is spawned by the Cursor extension, the extension already
+  // registers the MCP server via the cursor.mcp API on every activation.
+  // Writing a project-level entry on top of that creates a same-name
+  // duplicate whose command is either PATH-dependent (`axme-code` is not on
+  // PATH for extension-only users) or pinned to a version-numbered extension
+  // dir that goes stale on the next update. Skip the file entirely there.
+  if (process.env.AXME_SETUP_FROM_EXTENSION) return;
   const path = join(projectPath, ".cursor", "mcp.json");
   const cfg = readJsonOr<CursorMcpFile>(path, {});
+  if (cfg === null) {
+    console.error(`  ${path}: SKIPPED — existing file is not valid JSON. Fix or remove it, then re-run setup; refusing to overwrite user config.`);
+    return;
+  }
   if (!cfg.mcpServers) cfg.mcpServers = {};
   cfg.mcpServers.axme = { command: "axme-code", args: ["serve"] };
   writeJsonAtomic(path, cfg);
@@ -89,8 +109,17 @@ export function writeCursorHooksJson(
   projectPath: string,
   buildHookCommand: (hookName: string, projectPath: string) => string,
 ): void {
+  // Extension installs user-level hooks (~/.cursor/hooks.json) itself and
+  // rewrites them on every activation. A project-level copy written here
+  // would (a) double-fire every hook and (b) embed the setup-time absolute
+  // path of a version-numbered extension dir that nothing ever rewrites.
+  if (process.env.AXME_SETUP_FROM_EXTENSION) return;
   const path = join(projectPath, ".cursor", "hooks.json");
   const cfg = readJsonOr<CursorHooksFile>(path, { version: 1 });
+  if (cfg === null) {
+    console.error(`  ${path}: SKIPPED — existing file is not valid JSON. Fix or remove it, then re-run setup; refusing to overwrite user config.`);
+    return;
+  }
   if (!cfg.version) cfg.version = 1;
   if (!cfg.hooks) cfg.hooks = {};
 

--- a/src/storage/decisions.ts
+++ b/src/storage/decisions.ts
@@ -28,7 +28,29 @@ export function saveDecisions(projectPath: string, decisions: Decision[]): void 
   const existing = listDecisions(projectPath);
   const deduped = deduplicateDecisions(decisions, existing);
 
+  // Renumber any incoming decision whose pre-assigned id is already taken.
+  // Both the preset bundles and the init-scan parser number their batches
+  // from D-001 independently, so a first-run setup used to write D-001..D-009
+  // twice (slug-suffixed filenames mean no EEXIST protection) — making every
+  // later get/supersede/remove by id ambiguous. Allocation considers ALL
+  // stored decisions (including superseded) so retired ids are never reused.
+  const all = listDecisions(projectPath, { includeAll: true });
+  const used = new Set(all.map(d => d.id));
+  const nums = all
+    .map(d => parseInt(d.id.replace("D-", ""), 10))
+    .filter(n => Number.isFinite(n));
+  let nextNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
+
   for (const d of deduped) {
+    if (used.has(d.id)) {
+      // Advance past ids occupied by stored decisions AND by not-yet-written
+      // members of this same batch (a batch can carry a higher pre-assigned
+      // id than the current allocation cursor).
+      let candidate = `D-${String(nextNum++).padStart(3, "0")}`;
+      while (used.has(candidate)) candidate = `D-${String(nextNum++).padStart(3, "0")}`;
+      d.id = candidate;
+    }
+    used.add(d.id);
     atomicWrite(join(dir, `${d.id}-${d.slug}.md`), formatDecisionFile(d));
   }
   rebuildIndex(projectPath);

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -76,9 +76,15 @@ export function getFullContextSections(projectPath: string, workspacePath?: stri
     // Check if setup is already running
     const setupLock = join(projectPath, AXME_CODE_DIR, "setup.lock");
     if (pathExists(setupLock)) {
-      return [parts[0] + "\n\nSetup is already running. Wait for it to finish, then call axme_context again."];
+      return [parts[0] + "\n\nSetup is already running (`.axme-code/setup.lock` is present). Wait for it to finish, then call axme_context again. If the user says no setup is running, the lock is a leftover from an interrupted setup — it self-expires 15 minutes after it was written, or the user can re-run setup with `--force`."];
     }
-    return [parts[0] + "\n\nProject not initialized — `.axme-code/` is missing in this workspace. **Do NOT run `axme-code setup` yourself.** Initialization is the user's job (Cursor: run `AXME: Setup` from Command Palette; Claude Code: run `axme-code setup` in terminal). Tell the user this and stop; once they finish setup, call `axme_context` again and the knowledge base will load."];
+    // Canonical not-initialized flow — keep in sync with the PROJECT SETUP
+    // REQUIRED block in server.ts instructions and the CLAUDE.md section
+    // written by `check-init` (cli.ts). One story everywhere: offer the user
+    // setup, on consent EXECUTE the inline MCP-tool-call sequence. Never
+    // tell the agent to run `axme-code` via Bash — for plugin installs the
+    // binary is not on PATH and the call just fails.
+    return [parts[0] + "\n\nProject not initialized — `.axme-code/` storage is missing (or has no config). Offer the user AXME setup; on consent, EXECUTE the inline setup flow from the server instructions (the \"PROJECT SETUP REQUIRED\" block: a sequence of axme_save_decision / axme_save_memory / axme_update_safety / axme_save_oracle tool calls — the first save call auto-bootstraps `.axme-code/`). Do NOT run `axme-code setup` via the Bash tool — on plugin installs the binary is not on PATH. The user can alternatively run the deeper LLM scan themselves: `AXME: Setup` from the Command Palette (Cursor extension) or `axme-code setup` in a terminal (CLI installs)."];
   }
 
   // Safety rules (small, always inline)

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -6,7 +6,7 @@
  */
 
 import { join, basename } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { ensureDir, pathExists } from "../storage/engine.js";
 import { writeOracleFiles, initOracleDeterministic, oracleExists } from "../storage/oracle.js";
 import { initDecisionStore, saveDecisions, listDecisions } from "../storage/decisions.js";
@@ -39,6 +39,13 @@ export interface InitResult {
   scannersRun: number;
   /** Number of LLM scanners that failed (rejected or returned an error). Used for telemetry. */
   scannersFailed: number;
+  /**
+   * True when init was skipped because another setup currently holds a
+   * fresh setup.lock. Callers must surface this honestly — it used to be
+   * indistinguishable from "already initialized", which printed a
+   * misleading success message after interrupted setups.
+   */
+  lockSkipped?: boolean;
 }
 
 /**
@@ -73,21 +80,61 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
 
   ensureDir(axmeDir);
 
-  // Setup lock — prevent concurrent setup runs (plugin may trigger multiple)
+  // Setup lock — prevent concurrent setup runs (plugin may trigger multiple).
+  // The lock self-expires after 15 minutes: a setup killed mid-scan (Ctrl+C
+  // during the 1-2 min LLM phase is the most likely first-run interrupt)
+  // used to leave it behind forever, permanently bricking setup. --force
+  // bypasses it outright — the user explicitly asked to re-run.
   const lockPath = join(axmeDir, "setup.lock");
-  if (pathExists(lockPath)) {
-    return {
-      projectPath, created: false,
-      oracle: { files: 0, llm: false },
-      decisions: { count: 0, fromScan: 0, fromPresets: 0 },
-      memories: { count: 0, fromPresets: 0 },
-      safety: { created: false, llm: false, summary: "setup already running" },
-      config: false, cost: zeroCost(), durationMs: 0, errors: ["Setup already in progress"],
-      scannersRun: 0, scannersFailed: 0,
-    };
+  const LOCK_STALE_MS = 15 * 60 * 1000;
+  if (pathExists(lockPath) && !opts?.force) {
+    let stale = true;
+    try {
+      stale = Date.now() - statSync(lockPath).mtimeMs >= LOCK_STALE_MS;
+    } catch {
+      stale = true; // unreadable lock — treat as crashed leftover
+    }
+    if (!stale) {
+      return {
+        projectPath, created: false, lockSkipped: true,
+        oracle: { files: 0, llm: false },
+        decisions: { count: 0, fromScan: 0, fromPresets: 0 },
+        memories: { count: 0, fromPresets: 0 },
+        safety: { created: false, llm: false, summary: "setup already running" },
+        config: false, cost: zeroCost(), durationMs: 0, errors: ["Setup already in progress"],
+        scannersRun: 0, scannersFailed: 0,
+      };
+    }
+    // Stale lock from a crashed/killed setup — ignore it and proceed.
   }
   atomicWrite(lockPath, new Date().toISOString());
 
+  // Hold the lock for the entire scan and ALWAYS release it — including on
+  // throw or early return. Previously removal happened inline just before
+  // the success return, so any LLM-scanner exception (or process kill that
+  // Node still gets to unwind) left the lock behind permanently.
+  try {
+    return await runInitScanLocked(projectPath, opts, startTime, alreadyExists);
+  } finally {
+    try { removeFile(lockPath); } catch { /* best-effort */ }
+  }
+}
+
+/**
+ * Body of initProjectWithLLM, extracted so the caller can hold setup.lock
+ * in a try/finally around the whole scan.
+ */
+async function runInitScanLocked(
+  projectPath: string,
+  opts: {
+    presets?: string[];
+    workspaceMode?: boolean;
+    force?: boolean;
+    onProgress?: (msg: string) => void;
+  } | undefined,
+  startTime: number,
+  alreadyExists: boolean,
+): Promise<InitResult> {
   const presets = opts?.presets ?? DEFAULT_PROJECT_CONFIG.presets;
   let totalCost = zeroCost();
   const errors: string[] = [];
@@ -271,9 +318,6 @@ export async function initProjectWithLLM(projectPath: string, opts?: {
   } else if (oracleExists(projectPath) && !oracleLlm) {
     oracleFiles = 4;
   }
-
-  // Remove setup lock
-  try { removeFile(lockPath); } catch {}
 
   return {
     projectPath,

--- a/src/tools/status.ts
+++ b/src/tools/status.ts
@@ -14,7 +14,11 @@ import { AXME_CODE_DIR } from "../types.js";
 
 export function statusTool(projectPath: string): string {
   const initialized = pathExists(join(projectPath, AXME_CODE_DIR));
-  if (!initialized) return "Project not initialized. Run axme_init first.";
+  if (!initialized) {
+    // NB: keep aligned with the not-initialized flow in context.ts — there
+    // is no `axme_init` tool (removed long ago); the user runs setup.
+    return "Project not initialized. Run `axme-code setup` in a terminal (or `AXME: Setup` from the Cursor Command Palette), or follow the inline setup flow from axme_context.";
+  }
 
   const oracle = oracleExists(projectPath) ? "initialized" : "not initialized";
   const decisions = listDecisions(projectPath);


### PR DESCRIPTION
## Why

Pre-launch audit (4 parallel agents, every finding **reproduced against the released v0.6.0 artifacts**, not just code-read) surfaced first-run and channel-health bugs. This PR fixes everything CLI-side. Companion extension PR follows; release v0.6.1 after both.

## Fixes

### 1. Plugin audit pipeline was completely dead (CRITICAL)
`audit-spawner.ts` spawned `process.argv[1]` — correct for CLI installs, but plugin installs register `node ${CLAUDE_PLUGIN_ROOT}/server.mjs` as the MCP server, so finalize-close / disconnect-cleanup / orphan-recovery booted a **second MCP server** that immediately exited. Sessions were never audited; orphan recovery re-queued them forever. Now resolves the sibling `cli.mjs` when argv[1] is a server entry (covers plugin and npm-dist layouts). Verified present in the built `dist/plugin/server.mjs` with `cli.mjs` beside it.

### 2. Auto-update silently disabled for all binary users (CRITICAL)
`auto-update.ts:103` used `/releases/latest` — which currently resolves to `extension-v0.1.5`. `semverGreater("extension-v0.1.5", …)` compares NaN → always false → **no existing binary install would ever see v0.6.x**. Same bug class as the install.sh 404 fixed in edc4724; same fix (list endpoint + `^v[0-9]` filter).

### 3. `setup --help` ran a paid LLM scan into a literal `--help/` dir (CRITICAL)
Reproduced twice on the released binary ($0.49 / $0.77). Unknown flags now exit 2 with usage, `--help/-h` print usage, nonexistent paths are rejected (a typo'd path was silently created and scanned), >1 positional rejected.
Smoke-tested on the built bundle: `--help` → exit 0 + usage + **no dir created**; `--dry-run` → exit 2; bad path → exit 2.

### 4. Setup destroyed user config on invalid JSON (CRITICAL)
`.claude/settings.json`, `.mcp.json`, `.cursor/mcp.json`, `.cursor/hooks.json`: a hand-edited file with a comment/trailing comma hit `catch { = {} }` and was **silently replaced** (reproduced: user permissions, secret-bearing env vars, user's own hooks gone, exit 0). All four writers now refuse with an actionable error and keep going. Empty files still treated as fresh.

### 5. Interrupted setup bricked setup forever
`setup.lock` removal was inline before the success return — any scanner throw or Ctrl+C left it permanently; `--force` didn't bypass; rerun printed **"Already initialized … Done!"** (exit 0). Now: lock held in `try/finally`, self-expires after 15 min (mtime-based), `--force` bypasses, lock-skip reported honestly (exit 1 + recovery hint), `axme_context` lock message explains staleness.

### 6. Duplicate decision IDs on first run
Presets and init-scanner both number from D-001 → fresh setup wrote D-001..D-009 **twice** (verified in a live $0.77 setup), making every `get/supersede/remove` by id ambiguous. `saveDecisions` now renumbers colliding ids past max(all stored ids, including superseded) with batch-internal collision handling.

### 7. Three contradictory "not initialized" instructions
`server.ts` said "EXECUTE inline setup", `context.ts` said "do NOT run setup, tell the user", check-init CLAUDE.md said "run \`axme-code setup --plugin\` via Bash immediately" (binary not on PATH for plugin installs — guaranteed failed command). All four surfaces (incl. `status.ts`, which referenced the long-removed `axme_init`) now tell one story: offer the user setup → on consent EXECUTE the inline `axme_save_*` sequence; never invoke `axme-code` via Bash. Removed "runs inline on your **Cursor** subscription" copy shown to Claude Code users.

### 8. serverInfo version hardcoded "0.1.0"
Now reports the real release version — "which version is my IDE running" becomes debuggable.

### 9. Node-less installs looked successful, then crashed
The released "binaries" are Node single-file bundles (`#!/usr/bin/env node`); install.sh never checked for Node and the README only mentioned the requirement for Windows. install.sh now preflights Node 20+ (hard error if missing with `AXME_SKIP_NODE_CHECK=1` escape hatch, warning if <20); README documents the requirement for Linux/macOS. Also: version-arg example in the error hint updated `v0.1.0` → `v0.6.0` (v0.1.0 has no Windows assets).

### 10. Extension-spawned setup wrote stale/colliding project config
`writeCursorMcpJson`/`writeCursorHooksJson` now skip when `AXME_SETUP_FROM_EXTENSION` is set: the extension registers MCP via the cursor API on every activation and owns user-level hooks; the project-level files written before embedded version-numbered extension paths that went stale on every update and double-fired hooks. (Extension sets the env var in the companion PR.)

## Verification

- [x] 608/608 tests pass
- [x] `tsc --noEmit` clean, build clean, `bash -n install.sh` clean
- [x] Smoke on built bundle: setup flag/path validation (3 cases above)
- [x] `dist/plugin/server.mjs` contains sibling-cli resolution; `cli.mjs` present in plugin layout
- [x] No behavior change for valid configs / healthy flows (refuse-paths only fire on already-invalid JSON; lock paths only on contention/staleness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)