### PR TITLE
release: CLI v0.6.2 + extension v0.1.7 (Cursor session-close hotfix)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axme-code",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "(Alpha) Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.",
   "author": {
     "name": "AXME AI",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-11
+
+Hotfix release on top of v0.6.1, driven by the full functional QA pass of extension 0.1.6 on Cursor/Linux (23 of 25 executable checks passed; this release fixes the one real bug found).
+
+### Fixed
+
+- **Cursor extension: session close / audit pipeline / worklog were completely dead.** `axme_begin_close` (and `axme_finalize_close`) returned "No active AXME session found" on every Cursor extension install. Hooks record `ownerPpid` as their grandparent (one step above the `sh` wrapper) — under Claude Code that equals the MCP server's parent, so the strict `ownerPpid === process.ppid` ownership check worked; Cursor adds a process layer (hooks hang off the cursor-server main process, the MCP server is a child of the extension host), so strict equality never matched and the stale-adoption fallback never fired (the owner process is alive). Ownership checks now match against the server's ancestor PID chain (`getOwnAncestorPids`, depth 4): Linux walks `/proc`, macOS walks `ps`, Windows resolves the whole chain in a single PowerShell CIM call. `chain[0]` is `process.ppid`, so Claude Code behavior is unchanged. Verified E2E against the built server with an interposed process layer reproducing the Cursor topology, plus a selectivity control (alive unrelated owner PID still correctly reports no session) and a stale-adoption control (dead owner PID is still adopted — VS Code reload recovery preserved).
+
+### Added
+
+- **`channel-health.yml` scheduled workflow** (Mon+Thu + manual dispatch): verifies, from a fresh user's perspective, that npm latest / Open VSX latest / plugin-repo manifest match the newest release tags and that the community-marketplace SHA pin tracks the plugin repo HEAD (with a 48h grace window for Anthropic's auto-bump + nightly catalog sync). Opens a tracking issue on drift. The June postmortem gap — three channels drifted for weeks while every internal pipeline was green — is now a two-day detection window.
+- `scripts/release.sh` header + postflight now document the real community-marketplace pin process: the catalog repo is a read-only mirror (direct PRs are auto-closed by a bot); Anthropic's pipeline bumps approved plugins' pins on plugin-repo pushes with a nightly sync; escalate via the plugin-directory submission channel if the pin is stale more than 48h after a release.
+
 ## [0.6.1] - 2026-06-11
 
 Launch-readiness release. A four-agent audit of every distribution channel (standalone binary, npm, Claude Code plugin, Cursor extension) — with findings reproduced against the released v0.6.0 / extension-v0.1.5 artifacts — surfaced a set of first-run and channel-health bugs. This release fixes all of them and adds release-process guards so the channel breakages cannot silently recur.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "axme-code",
   "displayName": "AXME Code",
   "description": "Persistent memory, decisions, and safety guardrails for Cursor, GitHub Copilot, Cline, Continue, Roo Code, Windsurf, and VS Code chat agents",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "AxmeAI",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axme/code",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Persistent memory, decisions, and safety guardrails for Claude Code",
   "type": "module",
   "main": "./dist/server.js",

--- a/templates/plugin-README.md
+++ b/templates/plugin-README.md
@@ -5,7 +5,7 @@
 Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.
 
 [![Alpha](https://img.shields.io/badge/status-alpha-orange)]()
-[![Version](https://img.shields.io/badge/version-0.6.1-blue)]()
+[![Version](https://img.shields.io/badge/version-0.6.2-blue)]()
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 **[Main Repository](https://github.com/AxmeAI/axme-code)** · **[Website](https://code.axme.ai)** · **[Issues](https://github.com/AxmeAI/axme-code/issues)**


### PR DESCRIPTION
## Summary

Hotfix release shipping the QA-found Cursor session-ownership fix. **Merge order: #153 → this PR → push tags.** The version-drift CI guard will refuse to build if tags land before the bumps.

| Track | Old | New | Tag |
|---|---|---|---|
| CLI | 0.6.1 | **0.6.2** | `v0.6.2` |
| Extension | 0.1.6 | **0.1.7** | `extension-v0.1.7` |
| Plugin manifest | 0.6.1 | **0.6.2** | (ships via `v0.6.2` sync) |

## What ships

- **#153** — ancestor-chain session ownership: revives `axme_begin_close` / `axme_finalize_close` / audit pipeline / worklog for **all Cursor extension installs** (QA checks 2.6, 5.1–5.3). Claude Code path unchanged (`chain[0] == process.ppid`).
- CHANGELOG also records #152 (channel-health workflow + real marketplace-pin process docs), which is already on main.

## After merge

```bash
git checkout main && git pull origin main
git tag v0.6.2 && git push origin v0.6.2
git tag extension-v0.1.7 && git push origin extension-v0.1.7
```

Then I verify all channels and the Cursor QA agent can re-run checks 2.6 / 5.1–5.3 after the extension updates (Open VSX → Cursor sync, или sideload .vsix с GitHub Release сразу).

Note: the v0.6.2 plugin-repo sync will move HEAD again — if Anthropic's pipeline auto-bumps the marketplace pin (live test from v0.6.1 still running), it picks up 0.6.2 directly; channel-health.yml is watching either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)