### PR TITLE
release: CLI v0.6.3 + extension v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-25
+
+Reliability release for the `axme_save_memory` / `axme_save_decision` write tools, driven by two independent agent sessions that hit the same failure mode in production.
+
+### Fixed
+
+- **`axme_save_memory` (and `axme_save_decision`) repeatedly failed with `"expected string, received undefined"` on every required field** (#155). Two agent sessions independently hit this; the args object arrived empty (`{}`). Controlled testing confirmed it is **not** a server/handler/schema defect — every call whose arguments actually reached the server persisted correctly, and `axme_save_decision` worked in the same session with the same client. Root cause is a client-side generative slip: the agent emits the tool-call shell while deferring the heavy free-text fields, and the fill never happens. `axme_save_memory` is uniquely prone because it combines the heaviest required surface among the axme tools (enum `type` + two large free-text fields) with an over-generalized "batch axme calls in parallel" habit inherited from the read-tool instructions. The MCP SDK validates against the zod schema **before** the handler runs, so an empty payload never reaches our code and echoing the received keys would require loosening the advertised schema (which would worsen the root cause by hiding the required fields from the model). Three text-only mitigations instead, no schema loosening and no behavior change for valid calls:
+  - Custom zod v4 `{ error }` messages on the required fields of `axme_save_memory` (`type`/`title`/`description`) and `axme_save_decision` (`title`/`decision`/`reasoning`). Instead of a bland "received undefined" (which the first agent misread as "the server lost my arguments" and retried 9× before filing a server-bug report), each field now states it is REQUIRED, must be composed in the same call, and that an empty/deferred emission is the usual cause.
+  - Hardened tool descriptions: explicit "call standalone, not in a parallel batch; include all required fields in the same call" plus a worked example arguments object for `axme_save_memory`.
+  - Clarified server instructions: parallelism is for the READ tools (`axme_oracle`/`axme_decisions`/`axme_memories`) only; a new SAVE-TOOL RULE states `axme_save_memory`/`axme_save_decision`/`axme_update_safety` are called one at a time with all required fields composed in that same call.
+
 ## [0.6.2] - 2026-06-11
 
 Hotfix release on top of v0.6.1, driven by the full functional QA pass of extension 0.1.6 on Cursor/Linux (23 of 25 executable checks passed; this release fixes the one real bug found).

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "axme-code",
   "displayName": "AXME Code",
   "description": "Persistent memory, decisions, and safety guardrails for Cursor, GitHub Copilot, Cline, Continue, Roo Code, Windsurf, and VS Code chat agents",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "publisher": "AxmeAI",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axme/code",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Persistent memory, decisions, and safety guardrails for Claude Code",
   "type": "module",
   "main": "./dist/server.js",


### PR DESCRIPTION
## Summary

Combined release bump:

| Track | Old | New | Tag to push |
|---|---|---|---|
| CLI (`axme-code` binary) | 0.6.2 | **0.6.3** | `v0.6.3` |
| VS Code / Cursor extension | 0.1.7 | **0.1.8** | `extension-v0.1.8` |

CLI bump is PATCH (one bug fix, no new features). Extension bump is PATCH — it bundles the new CLI (the fix lives in `server.ts`, which the extension build inlines), no extension-side code change.

## What ships — the only change since v0.6.2

**[#155](https://github.com/AxmeAI/axme-code/pull/155) — `axme_save_memory` / `axme_save_decision` empty-args reliability.**

Two independent agent sessions hit `axme_save_memory` failing with `"expected string, received undefined"` on every required field (args arrived empty `{}`). Verified **not** a server/handler/schema defect — every call whose args actually reached the server persisted, and `save_decision` worked in the same session. Root cause: client-side generative slip (tool-call shell emitted without composing the heavy free-text fields), amplified by an over-generalized "batch axme calls in parallel" habit from the read-tool instructions.

The MCP SDK validates before our handler, so echoing received keys would require loosening the advertised schema (worsening the root cause). Three text-only mitigations instead — no schema loosening, no behavior change for valid calls:

1. **Custom zod v4 `{ error }` messages** on the required fields of both save tools — each says it is REQUIRED, must be composed in the same call, and that an empty/deferred emission is the usual cause. (Replaces the bland "received undefined" that the first agent misread as "the server lost my args" → 9× retry → false server-bug report.)
2. **Hardened tool descriptions** — "call standalone, not in a parallel batch; include all required fields in the same call" + a worked example arguments object.
3. **Clarified server instructions** — parallelism is for the READ tools only; a new SAVE-TOOL RULE for the write tools.

Full entry in [CHANGELOG.md](CHANGELOG.md).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` + `npm run build:extension` clean (extension reports v0.1.8)
- [x] `npm test` — 613/613 (one flaky concurrent-lock subtest passed on rerun; unrelated)

## After merge — push the two tags

The agent cannot push tags (safety hook). From a clean checkout of updated `main`:

```bash
git checkout main && git pull origin main

# CLI release → fires release-binary.yml (6 platform binaries + npm publish + plugin-repo sync)
git tag v0.6.3
git push origin v0.6.3

# Extension release → fires publish-extension.yml (5 platform .vsix → Open VSX + GitHub Release)
git tag extension-v0.1.8
git push origin extension-v0.1.8
```

Reminder from the last release cycle:
- **Merge this PR BEFORE pushing tags** — tags must point at the merge commit on `main` (last time we tagged before merge and both workflows built the old version).
- `npm publish` needs the **Classic Automation `NPM_TOKEN`** (not a granular/2FA token) — already fixed in the secret as of v0.6.0.

Watch: https://github.com/AxmeAI/axme-code/actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
