### PR TITLE
fix(release): bump missed lockstep manifests to 0.6.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axme-code",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "(Alpha) Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.",
   "author": {
     "name": "AXME AI",

--- a/templates/plugin-README.md
+++ b/templates/plugin-README.md
@@ -5,7 +5,7 @@
 Persistent memory, architectural decisions, and safety guardrails for Claude Code. Your agent starts every session with full project context — stack, decisions, patterns, safety rules, and a handoff from the previous session.
 
 [![Alpha](https://img.shields.io/badge/status-alpha-orange)]()
-[![Version](https://img.shields.io/badge/version-0.6.2-blue)]()
+[![Version](https://img.shields.io/badge/version-0.6.3-blue)]()
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 **[Main Repository](https://github.com/AxmeAI/axme-code)** · **[Website](https://code.axme.ai)** · **[Issues](https://github.com/AxmeAI/axme-code/issues)**


### PR DESCRIPTION
## Why

The v0.6.3 release ([#156](https://github.com/AxmeAI/axme-code/pull/156)) bumped `package.json` and `extension/package.json`, but **missed the other two CLI lockstep version files**. The `release-binary` workflow's `Verify tag matches version manifests` guard caught it and failed all 6 build jobs on the `v0.6.3` tag in ~5s:

```
::error::Version drift: tag v0.6.3 vs package.json 0.6.3 vs
.claude-plugin/plugin.json 0.6.2. Merge the release PR (which bumps all
manifests in lockstep) BEFORE pushing the tag, then re-tag on the merged commit.
```

`scripts/release.sh` defines the lockstep set (`VERSION_FILES`): `package.json`, `.claude-plugin/plugin.json`, `templates/plugin-README.md`. I bumped only the first when preparing #156 (my mental model was from pre-guard releases). This PR bumps the two that were missed.

> Note: the **extension** track was unaffected — `extension-v0.1.8` published successfully to Open VSX + GitHub Release. Only the CLI `v0.6.3` binary track needs a re-tag.

## Changes

- `.claude-plugin/plugin.json`: `0.6.2` → `0.6.3`
- `templates/plugin-README.md`: version badge `0.6.2` → `0.6.3`

Verified locally — all three lockstep files now read `0.6.3` and the CI guard's exact check passes.

## After merge — re-tag v0.6.3 on the merged commit

The previous `v0.6.3` tag points at the merge of #156 (which still has `plugin.json` 0.6.2). Move it to this fix's merge commit:

```bash
git checkout main && git pull origin main

# delete the stale tag locally + remote
git tag -d v0.6.3
git push origin :refs/tags/v0.6.3

# re-tag on the fixed HEAD + push → release-binary re-runs and passes the guard
git tag v0.6.3
git push origin v0.6.3
```

No extension re-tag needed (`extension-v0.1.8` already shipped). The failed `v0.6.3` build produced no release/npm/plugin side effects (it died at the verify step, before build/publish), so nothing to clean up.

## Follow-up (not in this PR)

`scripts/release.sh` already bumps all three files correctly — the miss was from hand-bumping. Consider having the release PR template / checklist call out the three lockstep files explicitly, or just always use `scripts/release.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
